### PR TITLE
Change placeholder to indicate password rules

### DIFF
--- a/assets/js/components/Sidebar/index.js
+++ b/assets/js/components/Sidebar/index.js
@@ -167,7 +167,7 @@ class Sidebar extends Component {
                                     minLength={6}
                                     className="form-control"
                                     id="password"
-                                    placeholder="Password at least 6 characters long" />
+                                    placeholder="Minimum of 6 characters" />
                             </div>
                             <button type="submit" className="btn">Update</button>
                             <button type="button" className="btn" onClick={() => this.setState({ profile: false, })}>Cancel</button>

--- a/assets/js/components/Sidebar/index.js
+++ b/assets/js/components/Sidebar/index.js
@@ -167,7 +167,7 @@ class Sidebar extends Component {
                                     minLength={6}
                                     className="form-control"
                                     id="password"
-                                    placeholder="6 character password" />
+                                    placeholder="Password at least 6 characters long" />
                             </div>
                             <button type="submit" className="btn">Update</button>
                             <button type="button" className="btn" onClick={() => this.setState({ profile: false, })}>Cancel</button>


### PR DESCRIPTION
This just makes the placeholder rules for the password clear: that 6 characters is the minimum and not the limit. (I confirmed that the site isn't truncating passwords to 6 characters or anything like that.)

I thought I spotted a misspelling in "LifeHacks" (as "LfieHacks") in the sidebar on mobile, but it looks correct here in `load_initial_data.js`), so I'm not sure why that was misspelled on my phone. Instead, I was able to fix up this small bit after I forked the repo. 

Thanks!