### PR TITLE
Fixed  URL Regex for Add Feed Dialog

### DIFF
--- a/assets/js/components/AddFeedDialog/index.js
+++ b/assets/js/components/AddFeedDialog/index.js
@@ -105,7 +105,7 @@ class AddFeedDialog extends Component {
                                         title="Please enter a valid site or feed URL"
                                         ref="url"
                                         className="url"
-                                        pattern="^(http|https|ftp)?(://)?(www|ftp)?.?[a-z0-9-]+(.|:)([a-z0-9-]+)+([/?].*)?$"
+                                        pattern="^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$"
                                         placeholder="Enter a valid site or feed URL"
                                         required={true}
                                         value={this.state.url}


### PR DESCRIPTION
Hi Nick

**Fix for issue:** https://github.com/GetStream/Winds/issues/59

Hasn't been tested as I need sleep, and couldn't get my local working.
On a personal note, it's probably better to take the response from the given url, and then parse it for 
feed properties (XML tags etc.) rather than regexing the URL, and if it return an error, just catch it and display an error.

URL Regex Taken from https://gist.github.com/dperini/729294 (MIT Licenced)