### PR TITLE
Fix hidden password field value in Safari

### DIFF
--- a/assets/js/containers/GetStarted/styles.scss
+++ b/assets/js/containers/GetStarted/styles.scss
@@ -415,13 +415,13 @@
             }
 
             input {
-                height: 30px;
+                height: 46px;
                 width: 75%;
                 padding-bottom: 16px;
                 border-bottom: 1px solid #FFFFFF;
                 padding-left: 50px;
                 padding-right: 50px;
-                color: #FFFFFF ;
+                color: #FFFFFF;
                 font-size: 16px;
                 text-align: center;
                 line-height: 30px;


### PR DESCRIPTION
The password field discs/bullets were not visible in Safari due to the height/padding associated with the password input field.

Resolves #86.