### PR TITLE
If favicon is not required it is ignored in API payload

### DIFF
--- a/api/models/Sites.js
+++ b/api/models/Sites.js
@@ -16,7 +16,8 @@ module.exports = {
             required: true,
         },
         faviconUrl: {
-            type: 'url'
+            type: 'url',
+            required: true
         },
         lastScraped: {
             type: 'datetime'


### PR DESCRIPTION
### Description 

Installed, configured, and started up the app to see that the site favicons weren't showing up. I used `node scrape_favicons.js --force` to ensure the favicons were actually downloaded but they still didn't show up. 

As far as I can see, the problem is that in the Sails model `faviconUrl` is not a `required` feed. Perhaps because the `sails` dependency is not pinned this has recently become a bug. 

An alternative is to pin back the Sails dependency (if dependency drift is actually the problem). 

### Risks:

- Low: Could *at worst* I think slow down API calls a bit