### PR TITLE
Feature/producthunt

### DIFF
--- a/api/src/controllers/article.js
+++ b/api/src/controllers/article.js
@@ -182,7 +182,6 @@ exports.get = (req, res) => {
 									let content = parsed.content
 									// XKCD doesn't like Mercury
 									if (article.url.indexOf('https://xkcd') == 0) {
-										console.log('xkcd', article.content)
 										 content = article.content
 									}
 
@@ -194,6 +193,7 @@ exports.get = (req, res) => {
 											parsed.date_published || moment().toDate(),
 										title: parsed.title,
 										url: article.url,
+										commentUrl: article.commentUrl,
 									})
 										.then(cache => {
 											cb(null, cache);

--- a/api/src/controllers/article.js
+++ b/api/src/controllers/article.js
@@ -124,6 +124,7 @@ exports.get = (req, res) => {
 	let query = req.query || {};
 
 	if (query.type === 'parsed') {
+
 		async.waterfall(
 			[
 				cb => {
@@ -177,8 +178,16 @@ exports.get = (req, res) => {
 							}
 							parser({ url: article.url })
 								.then(parsed => {
+
+									let content = parsed.content
+									// XKCD doesn't like Mercury
+									if (article.url.indexOf('https://xkcd') == 0) {
+										console.log('xkcd', article.content)
+										 content = article.content
+									}
+
 									Cache.create({
-										content: parsed.content,
+										content: content,
 										excerpt: parsed.excerpt,
 										image: parsed.lead_image_url || '',
 										publicationDate:

--- a/api/src/models/article.js
+++ b/api/src/models/article.js
@@ -45,6 +45,11 @@ export const ArticleSchema = new Schema(
 			maxLength: 240,
 			default: '',
 		},
+		commentUrl: {
+			type: String,
+			trim: true,
+			default: '',
+		},
 		images: {
 			featured: {
 				type: String,

--- a/api/src/models/article.js
+++ b/api/src/models/article.js
@@ -45,6 +45,11 @@ export const ArticleSchema = new Schema(
 			maxLength: 240,
 			default: '',
 		},
+		content: {
+			type: String,
+			trim: true,
+			default: '',
+		},
 		commentUrl: {
 			type: String,
 			trim: true,

--- a/api/src/workers/feed_debug.js
+++ b/api/src/workers/feed_debug.js
@@ -22,7 +22,11 @@ function main() {
 	let target = program.rss || program.podcast;
 	logger.info(`Looking up the first ${program.limit} articles from ${target}`);
 
-	function validate(articles, error) {
+	function validate(response, error) {
+		if (error) {
+			console.warn(error)
+		}
+		let articles = response.articles;
 		let selectedArticles = articles.slice(0, program.limit);
 		logger.info(`Found ${articles.length} articles showing ${program.limit}`);
 

--- a/api/src/workers/feed_debug.js
+++ b/api/src/workers/feed_debug.js
@@ -40,6 +40,9 @@ function main() {
 				if (article.commentUrl) {
 					logger.info(`Comments: ${article.commentUrl}`);
 				}
+				if (article.content) {
+					logger.info(`Content: ${article.content}`);
+				}
 				logger.info(chalk.red('Image is missing'));
 			}
 		} else {

--- a/api/src/workers/feed_debug.js
+++ b/api/src/workers/feed_debug.js
@@ -37,6 +37,9 @@ function main() {
 				logger.info(`URL: ${article.url}`);
 				logger.info(`Description: ${article.description}`);
 				logger.info(`Publication Date: ${article.publicationDate}`);
+				if (article.commentUrl) {
+					logger.info(`Comments: ${article.commentUrl}`);
+				}
 				logger.info(chalk.red('Image is missing'));
 			}
 		} else {

--- a/api/src/workers/package.json
+++ b/api/src/workers/package.json
@@ -21,6 +21,7 @@
 		"normalize-url": "^2.0.1",
 		"open-graph-scraper": "^3.3.0",
 		"request": "^2.85.0",
+		"sanitize-html": "^1.18.2",
 		"strip": "^3.0.0",
 		"winston": "^3.0.0-rc3",
 		"winston-sentry": "^0.2.1",

--- a/api/src/workers/parsers.js
+++ b/api/src/workers/parsers.js
@@ -1,4 +1,5 @@
 import strip from 'strip';
+import sanitizeHtml from 'sanitize-html';
 import entities from 'entities';
 import moment from 'moment';
 import request from 'request';
@@ -13,6 +14,17 @@ import Article from '../models/rss';
 
 import config from '../config'; // eslint-disable-line
 import logger from '../utils/logger';
+
+
+// sanitize cleans the html before returning it to the frontend
+var sanitize = function(dirty) {
+	return sanitizeHtml(dirty, {
+	  allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+		allowedAttributes: {
+			'img': [ 'src', 'title', 'alt' ]
+		},
+	});
+}
 
 function ParseFeed(feedUrl, callback) {
 	let req = request(feedUrl, {
@@ -64,19 +76,19 @@ function ParseFeed(feedUrl, callback) {
 
 		while ((postBuffer = feedparser.read())) {
 			let post = Object.assign({}, postBuffer);
-			let description = strip(
-				entities.decodeHTML(post.description).substring(0, 280),
-			);
 
-			if (description.length == 0 && post['atom:summary']) {
-				description = entities.decodeHTML(post['atom:summary']['#'])
-			}
+			let description = strip(
+					entities.decodeHTML(post.description).substring(0, 280),
+				)
+
 			let parsedArticle = {
 				description: description,
 				publicationDate:
 					moment(post.pubdate).toISOString() || moment().toISOString(),
 				title: strip(entities.decodeHTML(post.title)),
 				url: normalize(post.link),
+				// For some sites like XKCD the content from RSS is better than Mercury
+				content: sanitize(post.summary)
 			};
 
 			// nice for HNews

--- a/api/src/workers/parsers.js
+++ b/api/src/workers/parsers.js
@@ -91,9 +91,17 @@ function ParseFeed(feedUrl, callback) {
 				content: sanitize(post.summary)
 			};
 
-			// nice for HNews
+			// HNEWS
 			if (post.comments) {
 				parsedArticle.commentUrl = post.comments;
+			}
+
+			// product hunt comments url
+			if (post.link.indexOf('https://www.producthunt.com')==0) {
+				let matches = post.description.match(/(https:\/\/www.producthunt.com\/posts\/.*)"/)
+				if (matches.length) {
+					parsedArticle.commentUrl = matches[1];
+				}
 			}
 
 			feedContents.articles.push(parsedArticle);

--- a/api/src/workers/parsers.js
+++ b/api/src/workers/parsers.js
@@ -67,6 +67,7 @@ function ParseFeed(feedUrl, callback) {
 			let description = strip(
 				entities.decodeHTML(post.description).substring(0, 280),
 			);
+
 			if (description.length == 0 && post['atom:summary']) {
 				description = entities.decodeHTML(post['atom:summary']['#'])
 			}
@@ -77,6 +78,11 @@ function ParseFeed(feedUrl, callback) {
 				title: strip(entities.decodeHTML(post.title)),
 				url: normalize(post.link),
 			};
+
+			// nice for HNews
+			if (post.comments) {
+				parsedArticle.commentUrl = post.comments;
+			}
 
 			feedContents.articles.push(parsedArticle);
 			feedContents.metadata = post.meta;

--- a/api/src/workers/parsers.js
+++ b/api/src/workers/parsers.js
@@ -64,10 +64,14 @@ function ParseFeed(feedUrl, callback) {
 
 		while ((postBuffer = feedparser.read())) {
 			let post = Object.assign({}, postBuffer);
+			let description = strip(
+				entities.decodeHTML(post.description).substring(0, 280),
+			);
+			if (description.length == 0 && post['atom:summary']) {
+				description = entities.decodeHTML(post['atom:summary']['#'])
+			}
 			let parsedArticle = {
-				description: strip(
-					entities.decodeHTML(post.description).substring(0, 280),
-				),
+				description: description,
 				publicationDate:
 					moment(post.pubdate).toISOString() || moment().toISOString(),
 				title: strip(entities.decodeHTML(post.title)),

--- a/api/src/workers/rss.js
+++ b/api/src/workers/rss.js
@@ -76,6 +76,8 @@ rssQueue.process((job, done) => {
 							Article.create({
 								description: post.description,
 								publicationDate: post.publicationDate,
+								commentUrl: post.commentUrl,
+								content: post.content,
 								rss: job.data.rss,
 								title: post.title,
 								url: post.url,

--- a/api/src/workers/rss.js
+++ b/api/src/workers/rss.js
@@ -67,7 +67,7 @@ rssQueue.process((job, done) => {
 				10,
 				(post, cb) => {
 					// lookup by url
-					Article.findOne({ url: normalize(post.url) }).then(article => {
+					Article.findOne({ url: normalize(post.url),rss: job.data.rss }).then(article => {
 						if (article) {
 							// article already exists
 							cb(null, article);

--- a/api/src/workers/yarn.lock
+++ b/api/src/workers/yarn.lock
@@ -73,6 +73,12 @@ ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
@@ -156,6 +162,10 @@ array-sort@^0.1.2:
     default-compare "^1.0.0"
     get-value "^2.0.6"
     kind-of "^5.0.2"
+
+array-uniq@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -980,6 +990,14 @@ chalk@^2.0.1:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@^2.3.0, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 charenc@~0.0.1:
   version "0.0.2"
@@ -2009,6 +2027,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2091,7 +2113,7 @@ html-tag@^1.0.0:
     isobject "^3.0.0"
     void-elements "^2.0.1"
 
-htmlparser2@^3.9.1:
+htmlparser2@^3.9.0, htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -2677,6 +2699,10 @@ lodash.difference@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
 
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
@@ -2705,6 +2731,14 @@ lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -2716,6 +2750,10 @@ lodash.keys@^3.0.0:
 lodash.keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+
+lodash.mergewith@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
 lodash.noop@^3.0.1:
   version "3.0.1"
@@ -3294,6 +3332,14 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
+postcss@^6.0.14:
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -3681,6 +3727,21 @@ safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
+sanitize-html@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.18.2.tgz#61877ba5a910327e42880a28803c2fbafa8e4642"
+  dependencies:
+    chalk "^2.3.0"
+    htmlparser2 "^3.9.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.0"
+    postcss "^6.0.14"
+    srcset "^1.0.0"
+    xtend "^4.0.0"
+
 sax@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
@@ -3811,6 +3872,10 @@ source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
@@ -3820,6 +3885,13 @@ split@0.3:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+srcset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
+  dependencies:
+    array-uniq "^1.0.2"
+    number-is-nan "^1.0.0"
 
 sshpk@^1.7.0:
   version "1.13.1"
@@ -3937,6 +4009,12 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 tar-pack@^3.4.0:
   version "3.4.1"
@@ -4255,7 +4333,7 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
-xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Fixes RSS for XKCD, Product Hunt, Hacker News.

- disable mercury for XKCD
- parses summary and sticks it in article.content for XKCD
- commentUrl functionality for HNews & Product Hunt

Remaining issues:

- article uniqueness is defined based on article.url (it should probably be article.url + article.rss)
- show cache. commentUrl or article. commentUrl in the UI

https://trello.com/c/6Pu9ikpH/595-debug-popular-rss-feeds