### PR TITLE
"Featured" rss feeds / podcasts navigation fix

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
 		"node-sass-chokidar": "^1.2.2",
 		"numeral": "^2.0.6",
 		"opn": "^5.3.0",
+		"query-string": "^6.1.0",
 		"raven-js": "^3.24.2",
 		"rc-slider": "^8.6.1",
 		"react": "^16.3.2",

--- a/app/src/components/FeaturedItems.js
+++ b/app/src/components/FeaturedItems.js
@@ -43,9 +43,9 @@ class FeaturedItems extends React.Component {
 					{this.props.featuredItems.map(featuredItem => {
 						let linkURL = '#';
 						if (featuredItem.type === 'rss') {
-							linkURL = `/rss/${featuredItem._id}`;
+							linkURL = `/rss/${featuredItem._id}?featured=true`;
 						} else if (featuredItem.type === 'podcast') {
-							linkURL = `/podcasts/${featuredItem._id}`;
+							linkURL = `/podcasts/${featuredItem._id}?featured=true`;
 						}
 						return (
 							<Link

--- a/app/src/views/PodcastsView.js
+++ b/app/src/views/PodcastsView.js
@@ -1,3 +1,4 @@
+import queryString from 'query-string';
 import Tabs from '../components/Tabs';
 import RecentEpisodesPanel from '../components/PodcastPanels/RecentEpisodesPanel';
 import SuggestedPodcasts from '../components/PodcastPanels/SuggestedPodcasts';
@@ -55,7 +56,7 @@ class PodcastsView extends React.Component {
 	render() {
 		let headerComponent = <h1>Podcasts</h1>;
 		let leftColumn;
-		if (this.props.podcast && this.props.podcast.featured) {
+		if (queryString.parse(this.props.location.search).featured === 'true') {
 			leftColumn = (
 				<React.Fragment>
 					<div className="panels-header">

--- a/app/src/views/RSSFeedsView.js
+++ b/app/src/views/RSSFeedsView.js
@@ -12,6 +12,7 @@ import SuggestedFeeds from '../components/RSSPanels/SuggestedFeeds';
 import BookmarkedArticles from '../components/RSSPanels/BookmarkedArticles';
 import AllArticlesList from '../components/AllArticlesList';
 import RecentArticlesList from '../components/RecentArticlesList';
+import queryString from 'query-string';
 
 class RSSFeedsView extends React.Component {
 	constructor(props) {
@@ -49,9 +50,8 @@ class RSSFeedsView extends React.Component {
 	}
 
 	render() {
-		let headerComponent = <h1>RSS</h1>;
 		let leftColumn;
-		if (this.props.rssFeed && this.props.rssFeed.featured) {
+		if (queryString.parse(this.props.location.search).featured === 'true') {
 			leftColumn = (
 				<React.Fragment>
 					<div className="panels-header">
@@ -77,6 +77,8 @@ class RSSFeedsView extends React.Component {
 				</React.Fragment>
 			);
 		} else {
+			let headerComponent = <h1>RSS</h1>;
+
 			leftColumn = (
 				<Tabs
 					componentClass="panels"
@@ -114,6 +116,12 @@ class RSSFeedsView extends React.Component {
 		);
 	}
 }
+
+RSSFeedsView.defaultProps = {
+	rssFeed: {
+		images: {},
+	},
+};
 
 RSSFeedsView.propTypes = {
 	dispatch: PropTypes.func.isRequired,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -8371,6 +8371,13 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0, querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -9816,6 +9823,10 @@ stream-http@^2.3.1:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- if a "featured" rss feed / podcast is clicked on in the "featured" section, will display the "featured" view of the rss feed / podcast
- if a "featured" rss feed / podcast is clicked on **outside** of the "featured" section, will display the normal view for the rss feed / podcast