### PR TITLE
Corrected the name & URL of a podcast and added one other.

### DIFF
--- a/api/src/workers/featured.json
+++ b/api/src/workers/featured.json
@@ -210,9 +210,15 @@
 		},
 		{
 			"category": "Gaming",
-			"name": "Giantbomn",
+			"name": "Giant Bombcast",
 			"feedUrl": "https://www.giantbomb.com/podcast-xml/giant-bombcast",
-			"site": "https://www.giantbomb.com/podcasts/"
+			"site": "https://www.giantbomb.com/podcasts/giant-bombcast/"
+		},
+		{
+			"category": "Gaming",
+			"name": "The Giant Beastcast",
+			"feedUrl": "https://www.giantbomb.com/podcast-xml/beastcast",
+			"site": "https://www.giantbomb.com/podcasts/beastcast/"
 		},
 		{
 			"category": "Gaming",


### PR DESCRIPTION
### Description of the Change

Simply corrected the name & URL of an existing featured podcast. Also, added one additional featured podcast in that same category (gaming).

### Alternate Designs

N/A

### Why Should This Be in Core?

This is updating the built-in featured.json file.

### Benefits

Makes existing data more accurate and adds another popular gaming podcast to the featured list.

### Possible Drawbacks

The additional featured podcast might not be necessary.

### Applicable Issues

The original info for the Giant Bomb podcast had the name of "Giantbomn" when it's actually "Giant Bombcast" and also had a generic URL being used for the podcast's site (the site itself has multiple podcasts).