### PR TITLE
Change ambiguous "Go" label to a more descriptive verb-based label for the submit button in the Add RSS & Add Podcast popups.

### DIFF
--- a/app/src/components/AddPodcastModal.js
+++ b/app/src/components/AddPodcastModal.js
@@ -160,7 +160,7 @@ class AddPodcastModal extends React.Component {
 							type="submit"
 						>
 							<Img src={saveIcon} />
-							<span className="button-text">Go</span>
+							<span className="button-text">Add</span>
 						</button>
 						<button
 							className="btn link cancel"

--- a/app/src/components/AddPodcastModal.js
+++ b/app/src/components/AddPodcastModal.js
@@ -160,7 +160,7 @@ class AddPodcastModal extends React.Component {
 							type="submit"
 						>
 							<Img src={saveIcon} />
-							<span className="button-text">Add</span>
+							<span className="button-text">Add Podcast</span>
 						</button>
 						<button
 							className="btn link cancel"

--- a/app/src/components/AddRSSModal.js
+++ b/app/src/components/AddRSSModal.js
@@ -295,7 +295,7 @@ class AddRSSModal extends React.Component {
 							type="submit"
 						>
 							<Img src={saveIcon} />
-							<span className="button-text">Go</span>
+							<span className="button-text">Add</span>
 						</button>
 						<button
 							className="btn link cancel"

--- a/app/src/components/AddRSSModal.js
+++ b/app/src/components/AddRSSModal.js
@@ -285,18 +285,33 @@ class AddRSSModal extends React.Component {
 						) : null}
 					</div>
 					<div className="buttons">
-						<button
-							className="btn primary alt with-circular-icon"
-							disabled={
-								this.state.submitting ||
-								this.state.success ||
-								!this.stageOneFormIsValid()
-							}
-							type="submit"
-						>
-							<Img src={saveIcon} />
-							<span className="button-text">Add</span>
-						</button>
+						{this.state.opmlSectionExpanded ? (
+							<button
+								className="btn primary alt with-circular-icon"
+								disabled={
+									this.state.submitting ||
+									this.state.success ||
+									!this.stageOneFormIsValid()
+								}
+								type="submit"
+							>
+								<Img src={saveIcon} />
+								<span className="button-text">Import OPML</span>
+							</button>
+						) : (
+							<button
+								className="btn primary alt with-circular-icon"
+								disabled={
+									this.state.submitting ||
+									this.state.success ||
+									!this.stageOneFormIsValid()
+								}
+								type="submit"
+							>
+								<Img src={saveIcon} />
+								<span className="button-text">Add RSS</span>
+							</button>
+						)}
 						<button
 							className="btn link cancel"
 							onClick={e => {


### PR DESCRIPTION
### Description of the Change

A minor UI/UX improvement to the submit button on the Add RSS & Add Podcast popups. "Go" is generally a fallback option for a button as it's nondescript & requires understanding of the context. It's usually better to simply state the action that's going to be performed as the button's label to make it as clear as possible for the user. As such, the podcast popup has "Add Podcast" as the submit button's label, and the RSS popup switches between "Add RSS" and "Import OPML" depending if the "Import OPML" section has been expanded or not.

### Alternate Designs

The simple "Add" option was initially chosen for simplicity while still being an improvement. "Add / Import" was also considered since the user might be adding an RSS feed or Importing OPML using this one button. I then opted to have the button change to "Add RSS", "Import OMPL", and "Add Podcast" accordingly.

### Why Should This Be in Core?

This changes a UI element within the core app.

### Benefits

The user will better understand the action that will be performed when clicking the button that was updated.

### Possible Drawbacks

None that I can think of.

### Applicable Issues

Just a general UI/UX improvement here. No open issues to reference.