### PR TITLE
web app version: open links in browser, browser history

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <base target="_blank">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Winds - Powered by GetStream.io</title>
         <link href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" rel="stylesheet">

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -31,22 +31,33 @@ if (localStorage['dismissedIntroBanner'] === 'true') {
 	initialState['showIntroBanner'] = false;
 }
 
-let store = createStore(
-	reducer,
-	initialState,
-	window.__REDUX_DEVTOOLS_EXTENSION__ &&
-		window.__REDUX_DEVTOOLS_EXTENSION__({ maxAge: 1000 }),
-);
+var userAgent = navigator.userAgent.toLowerCase();
+let isElectron = userAgent.indexOf(' electron/') > -1;
 
-document.body.addEventListener('click', e => {
-	if (e.target.nodeName === 'A') {
-		const href = e.target.getAttribute('href');
-		if (!href.includes('#/')) {
-			e.preventDefault();
-			window.ipcRenderer.send('open-external-window', href);
+let store;
+
+if (isElectron) {
+	store = createStore(reducer, initialState);
+} else {
+	store = createStore(
+		reducer,
+		initialState,
+		window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+	);
+}
+
+if (isElectron) {
+	// Electron-specific code
+	document.body.addEventListener('click', e => {
+		if (e.target.nodeName === 'A') {
+			const href = e.target.getAttribute('href');
+			if (!href.includes('#/')) {
+				e.preventDefault();
+				window.ipcRenderer.send('open-external-window', href);
+			}
 		}
-	}
-});
+	});
+}
 
 class App extends Component {
 	render() {

--- a/app/src/AppRouter.js
+++ b/app/src/AppRouter.js
@@ -11,12 +11,21 @@ import { Router, Switch } from 'react-router-dom';
 import UnauthedRoute from './UnauthedRoute';
 import analytics from './util/tracking';
 import config from './config';
-import { createHashHistory } from 'history';
+import { createHashHistory, createBrowserHistory } from 'history';
 import fetch from './util/fetch';
 import AdminView from './views/AdminView';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
-const history = createHashHistory();
+var userAgent = navigator.userAgent.toLowerCase();
+let isElectron = userAgent.indexOf(' electron/') > -1;
+
+let history;
+if (isElectron) {
+	history = createHashHistory();
+} else {
+	history = createBrowserHistory();
+}
 
 history.listen(location => {
 	return analytics.pageview(`http://localhost:${config.port}`, location.pathname);
@@ -77,5 +86,9 @@ class AppRouter extends Component {
 		);
 	}
 }
+
+AppRouter.propTypes = {
+	dispatch: PropTypes.func.isRequired,
+};
 
 export default connect()(AppRouter);

--- a/app/src/components/Header.js
+++ b/app/src/components/Header.js
@@ -149,55 +149,101 @@ class Header extends Component {
 			</div>
 		);
 
-		let githubPopover = (
-			<div className="popover-panel github-popover">
-				<div
-					className="top"
-					onClick={e => {
-						e.preventDefault();
-						window.ipcRenderer.send(
-							'open-external-window',
-							'https://github.com/GetStream/Winds',
-						);
-					}}
-				>
-					<Img src={githubIcon} />
-					<a className="gh-button" href="https://github.com/GetStream/Winds">
-						<span className="gh-button__title">
-							<svg
-								className="gh-button__icon gh-button__icon--github-logo"
-								viewbox="0 0 1024 1024"
-							>
-								<path d="M512 0C229.252 0 0 229.25199999999995 0 512c0 226.251 146.688 418.126 350.155 485.813 25.593 4.686 34.937-11.125 34.937-24.626 0-12.188-0.469-52.562-0.718-95.314-128.708 23.46-161.707-31.541-172.469-60.373-5.525-14.809-30.407-60.249-52.398-72.263-17.988-9.828-43.26-33.237-0.917-33.735 40.434-0.476 69.348 37.308 78.471 52.75 45.938 77.749 119.876 55.627 148.999 42.5 4.654-32.999 17.902-55.627 32.501-68.373-113.657-12.939-233.22-56.875-233.22-253.063 0-55.94 19.968-101.561 52.658-137.404-5.22-12.999-22.844-65.095 5.063-135.563 0 0 42.937-13.749 140.811 52.501 40.811-11.406 84.594-17.031 128.124-17.22 43.499 0.188 87.314 5.874 128.188 17.28 97.689-66.311 140.686-52.501 140.686-52.501 28 70.532 10.375 122.564 5.124 135.499 32.811 35.844 52.626 81.468 52.626 137.404 0 196.686-119.751 240-233.813 252.686 18.439 15.876 34.748 47.001 34.748 94.748 0 68.437-0.686 123.627-0.686 140.501 0 13.625 9.312 29.561 35.25 24.562C877.436 929.998 1024 738.126 1024 512 1024 229.25199999999995 794.748 0 512 0z" />
-							</svg>
-							<span className="gh-button__title__text">Stars</span>
-						</span>
-						<span className="gh-button__stat">
-							<svg
-								className="gh-button__icon gh-button__icon--star"
-								viewbox="0 0 896 1024"
-							>
-								<path d="M896 384l-313.5-40.781L448 64 313.469 343.219 0 384l230.469 208.875L171 895.938l277-148.812 277.062 148.812L665.5 592.875 896 384z" />
-							</svg>
-							<span className="gh-button__stat__text">2,850</span>
-						</span>
+		// for the time being, setting up two github popovers - one for electron and one for web, to handle URLs correctly. will refactor later - <3, @kenhoff
+
+		var userAgent = navigator.userAgent.toLowerCase();
+		let isElectron = userAgent.indexOf(' electron/') > -1;
+		let githubPopover;
+
+		if (isElectron) {
+			githubPopover = (
+				<div className="popover-panel github-popover">
+					<div
+						className="top"
+						onClick={e => {
+							e.preventDefault();
+							window.ipcRenderer.send(
+								'open-external-window',
+								'https://github.com/GetStream/Winds',
+							);
+						}}
+					>
+						<Img src={githubIcon} />
+						<a
+							className="gh-button"
+							href="https://github.com/GetStream/Winds"
+						>
+							<span className="gh-button__title">
+								<svg
+									className="gh-button__icon gh-button__icon--github-logo"
+									viewbox="0 0 1024 1024"
+								>
+									<path d="M512 0C229.252 0 0 229.25199999999995 0 512c0 226.251 146.688 418.126 350.155 485.813 25.593 4.686 34.937-11.125 34.937-24.626 0-12.188-0.469-52.562-0.718-95.314-128.708 23.46-161.707-31.541-172.469-60.373-5.525-14.809-30.407-60.249-52.398-72.263-17.988-9.828-43.26-33.237-0.917-33.735 40.434-0.476 69.348 37.308 78.471 52.75 45.938 77.749 119.876 55.627 148.999 42.5 4.654-32.999 17.902-55.627 32.501-68.373-113.657-12.939-233.22-56.875-233.22-253.063 0-55.94 19.968-101.561 52.658-137.404-5.22-12.999-22.844-65.095 5.063-135.563 0 0 42.937-13.749 140.811 52.501 40.811-11.406 84.594-17.031 128.124-17.22 43.499 0.188 87.314 5.874 128.188 17.28 97.689-66.311 140.686-52.501 140.686-52.501 28 70.532 10.375 122.564 5.124 135.499 32.811 35.844 52.626 81.468 52.626 137.404 0 196.686-119.751 240-233.813 252.686 18.439 15.876 34.748 47.001 34.748 94.748 0 68.437-0.686 123.627-0.686 140.501 0 13.625 9.312 29.561 35.25 24.562C877.436 929.998 1024 738.126 1024 512 1024 229.25199999999995 794.748 0 512 0z" />
+								</svg>
+								<span className="gh-button__title__text">Stars</span>
+							</span>
+							<span className="gh-button__stat">
+								<svg
+									className="gh-button__icon gh-button__icon--star"
+									viewbox="0 0 896 1024"
+								>
+									<path d="M896 384l-313.5-40.781L448 64 313.469 343.219 0 384l230.469 208.875L171 895.938l277-148.812 277.062 148.812L665.5 592.875 896 384z" />
+								</svg>
+								<span className="gh-button__stat__text">3,944</span>
+							</span>
+						</a>
+					</div>
+					<a
+						className="bottom"
+						onClick={e => {
+							e.preventDefault();
+							window.ipcRenderer.send(
+								'open-external-window',
+								'https://github.com/GetStream/Winds',
+							);
+						}}
+					>
+						<span>View on GitHub</span>
+						<Img src={forwardIcon} />
 					</a>
 				</div>
-				<a
-					className="bottom"
-					onClick={e => {
-						e.preventDefault();
-						window.ipcRenderer.send(
-							'open-external-window',
-							'https://github.com/GetStream/Winds',
-						);
-					}}
-				>
-					<span>View on GitHub</span>
-					<Img src={forwardIcon} />
-				</a>
-			</div>
-		);
+			);
+		} else {
+			githubPopover = (
+				<div className="popover-panel github-popover">
+					<div className="top" href="https://github.com/GetStream/Winds">
+						<Img src={githubIcon} />
+						<a
+							className="gh-button"
+							href="https://github.com/GetStream/Winds"
+						>
+							<span className="gh-button__title">
+								<svg
+									className="gh-button__icon gh-button__icon--github-logo"
+									viewbox="0 0 1024 1024"
+								>
+									<path d="M512 0C229.252 0 0 229.25199999999995 0 512c0 226.251 146.688 418.126 350.155 485.813 25.593 4.686 34.937-11.125 34.937-24.626 0-12.188-0.469-52.562-0.718-95.314-128.708 23.46-161.707-31.541-172.469-60.373-5.525-14.809-30.407-60.249-52.398-72.263-17.988-9.828-43.26-33.237-0.917-33.735 40.434-0.476 69.348 37.308 78.471 52.75 45.938 77.749 119.876 55.627 148.999 42.5 4.654-32.999 17.902-55.627 32.501-68.373-113.657-12.939-233.22-56.875-233.22-253.063 0-55.94 19.968-101.561 52.658-137.404-5.22-12.999-22.844-65.095 5.063-135.563 0 0 42.937-13.749 140.811 52.501 40.811-11.406 84.594-17.031 128.124-17.22 43.499 0.188 87.314 5.874 128.188 17.28 97.689-66.311 140.686-52.501 140.686-52.501 28 70.532 10.375 122.564 5.124 135.499 32.811 35.844 52.626 81.468 52.626 137.404 0 196.686-119.751 240-233.813 252.686 18.439 15.876 34.748 47.001 34.748 94.748 0 68.437-0.686 123.627-0.686 140.501 0 13.625 9.312 29.561 35.25 24.562C877.436 929.998 1024 738.126 1024 512 1024 229.25199999999995 794.748 0 512 0z" />
+								</svg>
+								<span className="gh-button__title__text">Stars</span>
+							</span>
+							<span className="gh-button__stat">
+								<svg
+									className="gh-button__icon gh-button__icon--star"
+									viewbox="0 0 896 1024"
+								>
+									<path d="M896 384l-313.5-40.781L448 64 313.469 343.219 0 384l230.469 208.875L171 895.938l277-148.812 277.062 148.812L665.5 592.875 896 384z" />
+								</svg>
+								<span className="gh-button__stat__text">3,944</span>
+							</span>
+						</a>
+					</div>
+					<a className="bottom" href="https://github.com/GetStream/Winds">
+						<span>View on GitHub</span>
+						<Img src={forwardIcon} />
+					</a>
+				</div>
+			);
+		}
 
 		let header = (
 			<header className={'header'}>

--- a/app/src/styles/components/_popover-panel.scss
+++ b/app/src/styles/components/_popover-panel.scss
@@ -2,6 +2,9 @@
 	background-color: $background-white;
 	border-radius: $border-radius;
 	box-shadow: $box-shadow;
+	color: inherit;
+	display: block;
+	text-decoration: inherit;
 
 	.panel-element {
 		align-items: center;

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1328,7 +1328,10 @@ a.column-header:hover {
 .popover-panel {
   background-color: #fff;
   border-radius: 8px;
-  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.06), 0 2px 7px 0 rgba(0, 0, 0, 0.05); }
+  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.06), 0 2px 7px 0 rgba(0, 0, 0, 0.05);
+  color: inherit;
+  display: block;
+  text-decoration: inherit; }
   .popover-panel .panel-element {
     align-items: center;
     border-bottom: 1px solid #eee;


### PR DESCRIPTION
- sets base target to _blank
- only handling links for electron app - web app links should behave normally
- rendering two different github popover panels for the time being, will refactor later.
- using hash history for electron, browser history for web app