### PR TITLE
'Homepage' create-react-app parameter

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
 	"bugs": {
 		"url": "https://github.com/getstream/winds/issues"
 	},
-	"homepage": "./",
+	"homepage": "https://winds.getstream.io",
 	"main": "public/electron.js",
 	"keywords": [
 		"Winds",


### PR DESCRIPTION
Sets create react app to build with root URL in mind.