### PR TITLE
use await/async and skip useless extra work

### DIFF
--- a/api/src/utils/events/sendPodcastToCollections.js
+++ b/api/src/utils/events/sendPodcastToCollections.js
@@ -3,58 +3,29 @@ import Podcast from "../../models/podcast"
 import Episode from "../../models/episode"
 import detectPodcastLanguage from "../detectPodcastLanguage"
 
-export default podcastID => {
-    return new Promise((resolve, reject) => {
-        Podcast.findById(podcastID)
-            .then(podcast => {
-                // first, check if language is stored on podcast
-                if (!podcast.language) {
-                    return detectPodcastLanguage(podcast.feedUrl).then(language => {
-                        // save to podcast, return the modified document (the new: true thing)
-                        return Podcast.findByIdAndUpdate(
-                            podcastID,
-                            { language },
-                            { new: true },
-                        ).then(updatedPodcast => {
-                            // return new podcast
-                            return updatedPodcast
-                        })
-                    })
-                } else {
-                    return podcast
-                }
-            })
-            .then(podcast => {
-                // get number of episodes for this podcast, and the date for the most recently published episode
-                return Episode.find({
-                    podcast: podcastID,
-                })
-                    .sort({ publicationDate: -1 })
-                    .then(episodes => {
-                        // grab count and latest publicationDate
-                        return {
-                            articleCount: episodes.length,
-                            description: podcast.description,
-                            language: podcast.language,
-                            mostRecentPublicationDate: episodes[0].publicationDate,
-                            title: podcast.title,
-                        }
-                    })
-            })
-            .then(personalizationInfo => {
-                return events({
-                    meta: {
-                        data: {
-                            [`podcast:${podcastID}`]: personalizationInfo,
-                        },
-                    },
-                })
-            })
-            .then(() => {
-                resolve()
-            })
-            .catch(err => {
-                reject(err)
-            })
-    })
+async function sendPodcastToCollections(podcast) {
+	if (!podcast.language) {
+		podcast.language = await detectPodcastLanguage(podcast.feedUrl);
+		await Podcast.findByIdAndUpdate(podcast.id, { [language]: podcast.language }, { new: true });
+	}
+	let episodes = await Episode.find({
+		podcast: podcast.id,
+	}).sort({ publicationDate: -1 }).limit(1000)
+
+    let eventsData = {
+		[`podcast:${podcast.id}`]: {
+			articleCount: episodes.length,
+			description: podcast.description,
+			language: podcast.language,
+			mostRecentPublicationDate: episodes[0].publicationDate,
+			title: podcast.title,
+		}}
+
+	await events({
+		meta: {
+			data: eventsData,
+		},
+	});
 }
+
+export default sendPodcastToCollections

--- a/api/src/utils/events/sendRssFeedToCollections.js
+++ b/api/src/utils/events/sendRssFeedToCollections.js
@@ -10,23 +10,20 @@ async function sendRssFeedToCollections(rssFeed) {
 		await RSS.findByIdAndUpdate(rssFeed.id, { [language]: rssFeed.language }, { new: true });
 	}
 
-	let personalizationInfo = await Article.find({
+	let articles = await Article.find({
 		rss: rssFeed.id,
-	}).sort({ publicationDate: -1 }).limit(1000).then(articles => {
-		// grab count and latest publicationDate
-		return {
-			articleCount: articles.length,
-			description: rssFeed.description,
-			language: rssFeed.language,
-			mostRecentPublicationDate: articles[0].publicationDate,
-			title: rssFeed.title,
-		};
-	});
+	}).sort({ publicationDate: -1 }).limit(1000)
 
 	await events({
 		meta: {
 			data: {
-				[`rss:${rssFeed.id}`]: personalizationInfo,
+				[`rss:${rssFeed.id}`]: {
+					articleCount: articles.length,
+					description: rssFeed.description,
+					language: rssFeed.language,
+					mostRecentPublicationDate: articles[0].publicationDate,
+					title: rssFeed.title,
+				},
 			},
 		},
 	});

--- a/api/src/utils/events/sendRssFeedToCollections.js
+++ b/api/src/utils/events/sendRssFeedToCollections.js
@@ -12,7 +12,7 @@ async function sendRssFeedToCollections(rssFeed) {
 
 	let personalizationInfo = await Article.find({
 		rss: rssFeed.id,
-	}).sort({ publicationDate: -1 }).then(articles => {
+	}).sort({ publicationDate: -1 }).limit(1000).then(articles => {
 		// grab count and latest publicationDate
 		return {
 			articleCount: articles.length,

--- a/api/src/utils/events/sendRssFeedToCollections.js
+++ b/api/src/utils/events/sendRssFeedToCollections.js
@@ -1,58 +1,36 @@
-import events from "./index"
-import RSS from "../../models/rss"
-import Article from "../../models/article"
-import detectFeedLanguage from "../detectFeedLanguage"
+import events from './index';
+import RSS from '../../models/rss';
+import Article from '../../models/article';
+import detectFeedLanguage from '../detectFeedLanguage';
 
-export default rssFeedID => {
-    return new Promise((resolve, reject) => {
-        RSS.findById(rssFeedID)
-            .then(rssFeed => {
-                // first, check if language is stored on RSS feed
-                if (!rssFeed.language) {
-                    return detectFeedLanguage(rssFeed.feedUrl).then(language => {
-                        // save to feed, return the modified document (the new: true thing)
-                        return RSS.findByIdAndUpdate(rssFeedID, { language }, { new: true }).then(
-                            updatedRssFeed => {
-                                // return new feed
-                                return updatedRssFeed
-                            },
-                        )
-                    })
-                } else {
-                    return rssFeed
-                }
-            })
-            .then(rssFeed => {
-                // get number of articles for this feed, and the date for the most recently published article
-                return Article.find({
-                    rss: rssFeedID,
-                })
-                    .sort({ publicationDate: -1 })
-                    .then(articles => {
-                        // grab count and latest publicationDate
-                        return {
-                            articleCount: articles.length,
-                            description: rssFeed.description,
-                            language: rssFeed.language,
-                            mostRecentPublicationDate: articles[0].publicationDate,
-                            title: rssFeed.title,
-                        }
-                    })
-            })
-            .then(personalizationInfo => {
-                return events({
-                    meta: {
-                        data: {
-                            [`rss:${rssFeedID}`]: personalizationInfo,
-                        },
-                    },
-                })
-            })
-            .then(() => {
-                resolve()
-            })
-            .catch(err => {
-                reject(err)
-            })
-    })
+
+async function sendRssFeedToCollections(rssFeed) {
+	if (!rssFeed.language) {
+		rssFeed.language = await detectFeedLanguage(rssFeed.feedUrl);
+		await RSS.findByIdAndUpdate(rssFeed.id, { [language]: rssFeed.language }, { new: true });
+	}
+
+	let personalizationInfo = await Article.find({
+		rss: rssFeed.id,
+	}).sort({ publicationDate: -1 }).then(articles => {
+		// grab count and latest publicationDate
+		return {
+			articleCount: articles.length,
+			description: rssFeed.description,
+			language: rssFeed.language,
+			mostRecentPublicationDate: articles[0].publicationDate,
+			title: rssFeed.title,
+		};
+	});
+
+	await events({
+		meta: {
+			data: {
+				[`rss:${rssFeed.id}`]: personalizationInfo,
+			},
+		},
+	});
 }
+
+export default sendRssFeedToCollections;
+

--- a/api/src/workers/parsers.js
+++ b/api/src/workers/parsers.js
@@ -10,14 +10,11 @@ import podcastParser from "./podcast_parser_sax"
 
 import Podcast from "../models/podcast" // eslint-disable-line
 import Episode from "../models/episode"
-import Article from "../models/rss"
 
 import config from "../config" // eslint-disable-line
 import logger from "../utils/logger"
 
 const WindsUserAgent = "Winds: Open Source RSS & Podcast app: https://getstream.io/winds/"
-const BrowserUserAgent =
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36"
 const AcceptHeader = "text/html,application/xhtml+xml,application/xml"
 
 // sanitize cleans the html before returning it to the frontend

--- a/api/src/workers/podcast.js
+++ b/api/src/workers/podcast.js
@@ -11,7 +11,6 @@ import Episode from "../models/episode"
 import "../utils/db"
 import config from "../config"
 import logger from "../utils/logger"
-import search from "../utils/search"
 import sendPodcastToCollections from "../utils/events/sendPodcastToCollections"
 import { ParsePodcast } from "./parsers"
 import util from "util"
@@ -47,7 +46,7 @@ async function _handlePodcast(job) {
 
     // mark as done, will be schedule again in 15 min from now
     // we do this early so a temporary failure doesnt leave things in a broken state
-    let completed = await markDone(podcastID)
+    await markDone(podcastID)
 
     // parse the episodes
     let podcastContent
@@ -89,11 +88,11 @@ async function _handlePodcast(job) {
             })
 
             // addActivities to Stream
-            let streamResponse = await podcastFeed.addActivities(streamEpisodes)
-            // update the collection information for follow suggestions
-            let collectionResponse = await sendPodcastToCollections(podcastID)
+            await podcastFeed.addActivities(streamEpisodes)
         }
-    }
+		// update the collection information for follow suggestions
+		await sendPodcastToCollections(podcast)
+	}
 }
 
 // updateEpisode updates 1 episode and sync the data to og scraping

--- a/api/src/workers/rss.js
+++ b/api/src/workers/rss.js
@@ -49,7 +49,7 @@ async function handleRSS(job) {
 
     // mark as done, will be schedule again in 15 min from now
     // we do this early so a temporary failure doesnt leave things in a broken state
-    let completed = await markDone(rssID)
+    await markDone(rssID)
     logger.info(`Marked ${rssID} as done`)
 
     // parse the articles
@@ -93,9 +93,9 @@ async function handleRSS(job) {
                 }
             })
 
-            let streamResponse = await rssFeed.addActivities(streamArticles)
-            let response = await sendRssFeedToCollections(job.data.rss)
+            await rssFeed.addActivities(streamArticles)
         }
+		await sendRssFeedToCollections(rss)
     }
     logger.info(`Completed scraping for ${job.data.url}`)
 }

--- a/api/src/workers/rss.js
+++ b/api/src/workers/rss.js
@@ -71,7 +71,7 @@ async function handleRSS(job) {
         }),
     )
 
-    // updatedArticles will contain `null` for all articles that didn't get updated, that we alrady have in the system.
+    // updatedArticles will contain `null` for all articles that didn't get updated, that we already have in the system.
     let updatedArticles = allArticles.filter(updatedArticle => {
         return updatedArticle
     })


### PR DESCRIPTION
- save 1 useless Mongo read
- refactor and use async/await
- call `sendRssFeedToCollections` once per feed
- limit max amount of articles to fetch to 1k