### PR TITLE
Resolves an unhandled promise rejection warning due invalid response …

### DIFF
--- a/api/src/controllers/podcast.js
+++ b/api/src/controllers/podcast.js
@@ -37,7 +37,7 @@ exports.list = (req, res) => {
                 res.json(results);
             })
             .catch(err => {
-                res.status(500).send(err);
+                res.status(500).send(err.errors);
             });
     } else {
         Podcast.apiQuery(req.query)


### PR DESCRIPTION
Fixes this log spam:

```
0|api      | (node:94197) UnhandledPromiseRejectionWarning: TypeError: Converting circular structure to JSON
0|api      |     at JSON.stringify (<anonymous>)
0|api      |     at stringify (/Users/dwight/projects/git/stream/Winds/api/node_modules/express/lib/response.js:1118:12)
0|api      |     at ServerResponse.json (/Users/dwight/projects/git/stream/Winds/api/node_modules/express/lib/response.js:260:14)
0|api      |     at ServerResponse.send (/Users/dwight/projects/git/stream/Winds/api/node_modules/express/lib/response.js:158:21)
0|api      |     at then.then.catch.err (/Users/dwight/projects/git/stream/Winds/api/src/controllers/podcast.js:40:33)
0|api      |     at <anonymous>
0|api      |     at process._tickCallback (internal/process/next_tick.js:118:7)
0|api      | (node:94197) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
```