### PR TITLE
Feature/sentry refactoring

### DIFF
--- a/api/src/controllers/health.js
+++ b/api/src/controllers/health.js
@@ -2,13 +2,13 @@ import Article from "../models/article"
 import Episode from "../models/episode"
 import RSS from "../models/rss"
 import Podcast from "../models/podcast"
-import logger from "../utils/logger"
 import moment from "moment"
 import config from "../config"
 
 import { version } from "../../../app/package.json"
-
+import { Throw } from "../utils/errors"
 import Queue from 'bull';
+import logger from "../utils/logger"
 
 const rssQueue = new Queue('rss', config.cache.uri);
 const ogQueue = new Queue('og', config.cache.uri);
@@ -21,8 +21,6 @@ const queues = {
 	'Podcast Queue': podcastQueue,
 }
 
-
-// Is the webserver running.... yes no
 exports.health = (req, res) => {
     res.status(200).send({ version, healthy: "100%" })
 }
@@ -81,4 +79,24 @@ exports.status = async (req, res) => {
 
     // send the response
     res.status(output.code).send(output)
+}
+
+exports.sentryThrow = (req, res) => {
+	Throw()
+}
+
+exports.sentryLog = async (req, res) => {
+    try {
+		    Throw()
+    } catch (err) {
+		    logger.error(err)
+    }
+  try {
+    Throw()
+  } catch (err) {
+    logger.error(err)
+  }
+  logger.error('0')
+  logger.error('1')
+	res.status(200).send("{}")
 }

--- a/api/src/routes/health.js
+++ b/api/src/routes/health.js
@@ -1,14 +1,10 @@
 import Health from "../controllers/health"
+import { wrapAsync } from "../utils/controllers"
 
-const asyncMiddleware = fn =>
-	(req, res, next) => {
-		Promise.resolve(fn(req, res, next))
-			.catch(next);
-	};
 
 module.exports = api => {
-    api.route("/health").get(Health.health)
-    api.route("/status").get(Health.status)
-    api.route("/sentry/log").get(asyncMiddleware(Health.sentryLog))
-    api.route("/sentry/throw").get(asyncMiddleware(Health.sentryThrow))
+    api.route("/health").get(wrapAsync(Health.health))
+    api.route("/status").get(wrapAsync(Health.status))
+    api.route("/sentry/log").get(wrapAsync(Health.sentryLog))
+    api.route("/sentry/throw").get(wrapAsync(Health.sentryThrow))
 }

--- a/api/src/routes/health.js
+++ b/api/src/routes/health.js
@@ -1,6 +1,14 @@
 import Health from "../controllers/health"
 
+const asyncMiddleware = fn =>
+	(req, res, next) => {
+		Promise.resolve(fn(req, res, next))
+			.catch(next);
+	};
+
 module.exports = api => {
     api.route("/health").get(Health.health)
     api.route("/status").get(Health.status)
+    api.route("/sentry/log").get(asyncMiddleware(Health.sentryLog))
+    api.route("/sentry/throw").get(asyncMiddleware(Health.sentryThrow))
 }

--- a/api/src/utils/controllers.js
+++ b/api/src/utils/controllers.js
@@ -1,0 +1,9 @@
+function wrapAsync(fn) {
+  return function(req, res, next) {
+    // Make sure to `.catch()` any errors and pass them along to the `next()`
+    // middleware in the chain, in this case the error handler.
+    fn(req, res, next).catch(next);
+  };
+}
+
+exports.wrapAsync = wrapAsync

--- a/api/src/utils/errors.js
+++ b/api/src/utils/errors.js
@@ -21,7 +21,7 @@ function sendSourceMaps(data){
 
 let sentryOptions = {
     dsn: config.sentry.dsn,
-    level: "warn",
+    level: "error",
     patchGlobal: config.env === "production",
 		environment: config.env,
     tags: { script: executable },

--- a/api/src/utils/errors.js
+++ b/api/src/utils/errors.js
@@ -1,24 +1,58 @@
 import config from "../config"
-import winston from "winston"
 import Raven from "raven"
 import path from "path"
-
-let readmePath = require.resolve("raven")
+import { version } from "../../../app/package.json"
+require.resolve("raven")
 
 const executable = path.basename(process.argv[1])
 var ravenInstance
 
+function sendSourceMaps(data){
+	var stacktrace = data.exception && data.exception[0].stacktrace
+	if (stacktrace && stacktrace.frames) {
+		stacktrace.frames.forEach(function(frame) {
+			if (frame.filename.indexOf('/api/dist/') !== -1 ) {
+				frame.filename = `app:///${frame.filename.split('api/dist/')[1]}`
+			}
+		});
+	}
+	return data
+}
+
 let sentryOptions = {
     dsn: config.sentry.dsn,
     level: "warn",
-    patchGlobal: config.env == "production",
-    tags: { key: executable },
+    patchGlobal: config.env === "production",
+		environment: config.env,
+    tags: { script: executable },
+		dataCallback: sendSourceMaps,
+		release: version,
 }
+
 ravenInstance = Raven.config(sentryOptions.dsn, sentryOptions)
-ravenInstance.install()
+
+if (config.sentry.dsn) {
+	ravenInstance.install()
+}
 
 function captureError(err, msg) {
     Raven.captureException(err)
+}
+
+exports.setupExpressRequestHandler = (app) => {
+	if (ravenInstance) {
+		app.use(ravenInstance.requestHandler())
+	}
+}
+
+exports.setupExpressErrorHandler = (app) => {
+	if (ravenInstance) {
+		app.use(ravenInstance.errorHandler())
+	}
+}
+
+exports.Throw = () => {
+	throw new Error("test")
 }
 
 exports.Raven = ravenInstance

--- a/api/src/utils/logger/index.js
+++ b/api/src/utils/logger/index.js
@@ -1,12 +1,10 @@
 import config from "../../config"
 import winston from "winston"
 import { createSentryTransport } from "./sentry"
-import path from "path"
 import { Raven } from "../errors"
 
 // https://github.com/guzru/winston-sentry
 const transports = [new winston.transports.Console({ level: "silly" })]
-const executable = path.basename(process.argv[1])
 
 if (config.sentry.dsn) {
     let sentryTransport = createSentryTransport(Raven)

--- a/api/src/workers/podcast.js
+++ b/api/src/workers/podcast.js
@@ -27,7 +27,8 @@ async_tasks.ProcessPodcastQueue(5, handlePodcast)
 async function handlePodcast(job) {
     let promise = _handlePodcast(job)
     promise.catch(err => {
-        logger.warn(`podcast job ${job} broke with err ${err}`)
+        logger.info(`podcast job ${job} broke with err ${err}`)
+      	logger.error(err)
     })
     return promise
 }

--- a/api/src/workers/rss.js
+++ b/api/src/workers/rss.js
@@ -32,9 +32,8 @@ const statsd = getStatsDClient()
 async function handleRSS(job) {
     let promise = _handleRSS(job)
     promise.catch(err => {
-        logger.warn(`rss job ${job} broke with err ${err}`)
-        console.log(err)
-
+        logger.info(`rss job ${job} broke with err ${err}`)
+        logger.error(err)
     })
     return promise
 }


### PR DESCRIPTION
- Make sure that `logger.error(err)` and `logger.error("err")` both works
- Make sure we sent error's stack traces from logging
- Stacktraces from `/dist/` are now rewritten to work on Sentry
- Add test Sentry handlers `/sentry/log` and /sentry/throw`
- Change `server.js` to allow Sentry request and error handlers
- Add `wrapAsync` wrapper to catch unhandled errors from async controllers