### PR TITLE
Fixing new podcast / rss feed redirect

### DIFF
--- a/api/src/shared/followPodcast.js
+++ b/api/src/shared/followPodcast.js
@@ -18,6 +18,9 @@ const followPodcast = (userID, podcastID) => {
 	};
 	return Follow.findOne(obj).then(existingFollow => {
 		if (existingFollow) {
+			// serialize podcast and user ids
+			existingFollow.podcast = existingFollow.podcast._id;
+			existingFollow.user = existingFollow.user._id;
 			return existingFollow;
 		} else {
 			return Promise.all([

--- a/api/src/shared/followRssFeed.js
+++ b/api/src/shared/followRssFeed.js
@@ -17,6 +17,9 @@ const followRssFeed = (userID, rssFeedID) => {
 	};
 	return Follow.findOne(obj).then(existingFollow => {
 		if (existingFollow) {
+			// serialize rss and user ids
+			existingFollow.rss = existingFollow.rss._id;
+			existingFollow.user = existingFollow.user._id;
 			return existingFollow;
 		} else {
 			return Promise.all([

--- a/app/src/components/RSSArticleList.js
+++ b/app/src/components/RSSArticleList.js
@@ -43,17 +43,19 @@ class RSSArticleList extends React.Component {
 	}
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.match.params.rssFeedID !== this.props.match.params.rssFeedID) {
-			console.log("next props did not match");
 			// if navigating between rss feeds
-			this.setState({
-				articleCursor: 1,
-			}, () => {
-				this.getRSSFeed(nextProps.match.params.rssFeedID);
-				this.getFollowState(nextProps.match.params.rssFeedID);
-				this.getRSSArticles(nextProps.match.params.rssFeedID);
-				getPinnedArticles(this.props.dispatch);
-				getFeed(this.props.dispatch, 'article', 0, 20);
-			});
+			this.setState(
+				{
+					articleCursor: 1,
+				},
+				() => {
+					this.getRSSFeed(nextProps.match.params.rssFeedID);
+					this.getFollowState(nextProps.match.params.rssFeedID);
+					this.getRSSArticles(nextProps.match.params.rssFeedID);
+					getPinnedArticles(this.props.dispatch);
+					getFeed(this.props.dispatch, 'article', 0, 20);
+				},
+			);
 		}
 	}
 	getRSSFeed(rssFeedID) {


### PR DESCRIPTION
- mentioned in https://github.com/GetStream/Winds/issues/313#issuecomment-392920403
- fixes a situation where a user adds a podcast / rss feed from the "add new" modal, and then attempts to follow a feed that they're already following (previously, redirected to `https://winds.getstream.io/rss/[object%20Object]` 
- also cleans up 1 logging statement from `AddRSSModal`