### PR TITLE
Sentry fixes, part 1

### DIFF
--- a/app/src/components/RecentArticlesList.js
+++ b/app/src/components/RecentArticlesList.js
@@ -20,18 +20,7 @@ class RecentArticlesList extends React.Component {
 
 				<div className="list content">
 					{this.props.articles.map(article => {
-						return (
-							<ArticleListItem
-								key={article._id}
-								pinArticle={() => {
-									this.props.pinArticle(article._id);
-								}}
-								unpinArticle={() => {
-									this.props.unpinArticle(article.pinID, article._id);
-								}}
-								{...article}
-							/>
-						);
+						return <ArticleListItem key={article._id} {...article} />;
 					})}
 				</div>
 			</React.Fragment>
@@ -46,8 +35,6 @@ RecentArticlesList.defaultProps = {
 RecentArticlesList.propTypes = {
 	articles: PropTypes.arrayOf(PropTypes.shape({})),
 	dispatch: PropTypes.func.isRequired,
-	pinArticle: PropTypes.func.isRequired,
-	unpinArticle: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/app/src/views/PodcastsView.js
+++ b/app/src/views/PodcastsView.js
@@ -23,7 +23,10 @@ class PodcastsView extends React.Component {
 	}
 	componentDidMount() {
 		// fetch new podcast
-		if (this.props.match.params.podcastID) {
+		if (
+			this.props.match.params.podcastID &&
+			this.props.match.params.podcastID !== 'recent'
+		) {
 			fetch('get', `/podcasts/${this.props.match.params.podcastID}`).then(
 				response => {
 					this.props.dispatch({
@@ -108,7 +111,8 @@ class PodcastsView extends React.Component {
 		return (
 			<div
 				className={`podcasts-view ${
-					new URLSearchParams(this.props.location.search).get('featured') === 'true'
+					new URLSearchParams(this.props.location.search).get('featured') ===
+					'true'
 						? 'featured'
 						: ''
 				}`}

--- a/app/src/views/PodcastsView.js
+++ b/app/src/views/PodcastsView.js
@@ -140,6 +140,7 @@ PodcastsView.propTypes = {
 			podcastID: PropTypes.string,
 		}).isRequired,
 	}).isRequired,
+	location: PropTypes.shape({ search: PropTypes.string }).isRequired,
 	podcast: PropTypes.shape({
 		_id: PropTypes.string,
 		description: PropTypes.string,

--- a/app/src/views/RSSFeedsView.js
+++ b/app/src/views/RSSFeedsView.js
@@ -24,7 +24,10 @@ class RSSFeedsView extends React.Component {
 	}
 
 	componentDidMount() {
-		if (this.props.match.params.rssFeedID) {
+		if (
+			this.props.match.params.rssFeedID &&
+			this.props.match.params.rssFeedID !== 'recent'
+		) {
 			fetch('get', `/rss/${this.props.match.params.rssFeedID}`).then(response => {
 				this.props.dispatch({
 					rssFeed: response.data,

--- a/app/src/views/RSSFeedsView.js
+++ b/app/src/views/RSSFeedsView.js
@@ -144,7 +144,7 @@ RSSFeedsView.propTypes = {
 		}).isRequired,
 	}).isRequired,
 	rssFeed: PropTypes.shape({
-		_id: PropTypes.string.isRequired,
+		_id: PropTypes.string,
 		description: PropTypes.string,
 		featured: PropTypes.boolean,
 		images: PropTypes.shape({


### PR DESCRIPTION
- removes unnecessary required props from `RecentArticlesList`
- removes API request when accessing `/rss/recent`