### PR TITLE
Saving scroll position on Article list views

### DIFF
--- a/app/src/components/AllArticlesList.js
+++ b/app/src/components/AllArticlesList.js
@@ -16,10 +16,21 @@ class AllArticles extends React.Component {
 			cursor: 0,
 			reachedEndOfFeed: false,
 		};
+
+		this.contentsEl = React.createRef();
 	}
 	componentDidMount() {
 		this.getArticleFeed();
 		getPinnedArticles(this.props.dispatch);
+	}
+	componentWillReceiveProps() {
+		// scroll down to last saved position, then delete from localStorage
+		// note from Ken - this works because we've still got all the articles loaded into the frontend - no need to maintain pagination position
+		if (this.contentsEl.current && localStorage['all-article-list-scroll-position']) {
+			this.contentsEl.current.scrollTop =
+				localStorage['all-article-list-scroll-position'];
+			delete localStorage['all-article-list-scroll-position'];
+		}
 	}
 	getArticleFeed() {
 		getFeed(this.props.dispatch, 'article', this.state.cursor, 10);
@@ -31,16 +42,15 @@ class AllArticles extends React.Component {
 					<h1>All Articles</h1>
 				</div>
 
-				<div className="list content">
+				<div className="list content" ref={this.contentsEl}>
 					{this.props.articles.map(article => {
 						return (
 							<ArticleListItem
 								key={article._id}
-								pinArticle={() => {
-									this.props.pinArticle(article._id);
-								}}
-								unpinArticle={() => {
-									this.props.unpinArticle(article.pinID, article._id);
+								onNavigation={() => {
+									localStorage[
+										'all-article-list-scroll-position'
+									] = this.contentsEl.current.scrollTop;
 								}}
 								{...article}
 							/>
@@ -48,10 +58,10 @@ class AllArticles extends React.Component {
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{'That\'s it! No more articles here.'}</p>
+							<p>{"That's it! No more articles here."}</p>
 							<p>
 								{
-									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
+									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
 								}
 							</p>
 						</div>
@@ -87,8 +97,6 @@ AllArticles.defaultProps = {
 AllArticles.propTypes = {
 	articles: PropTypes.arrayOf(PropTypes.shape({})),
 	dispatch: PropTypes.func.isRequired,
-	pinArticle: PropTypes.func,
-	unpinArticle: PropTypes.func,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/app/src/components/ArticleListItem.js
+++ b/app/src/components/ArticleListItem.js
@@ -12,6 +12,9 @@ class ArticleListItem extends React.Component {
 			<div
 				className="list-item"
 				onClick={() => {
+					if (this.props.onNavigation) {
+						this.props.onNavigation();
+					}
 					this.props.history.push(
 						`/rss/${this.props.rss._id}/articles/${this.props._id}`,
 					);
@@ -93,6 +96,7 @@ ArticleListItem.propTypes = {
 	images: PropTypes.shape({
 		og: PropTypes.string,
 	}),
+	onNavigation: PropTypes.func,
 	pinID: PropTypes.string,
 	pinned: PropTypes.bool,
 	publicationDate: PropTypes.string,

--- a/app/src/components/RSSArticleList.js
+++ b/app/src/components/RSSArticleList.js
@@ -26,6 +26,8 @@ class RSSArticleList extends React.Component {
 		this.getRSSArticles = this.getRSSArticles.bind(this);
 		this.getFollowState = this.getFollowState.bind(this);
 		this.toggleMenu = this.toggleMenu.bind(this);
+
+		this.contentsEl = React.createRef();
 	}
 
 	toggleMenu() {
@@ -56,6 +58,14 @@ class RSSArticleList extends React.Component {
 					getFeed(this.props.dispatch, 'article', 0, 20);
 				},
 			);
+		}
+
+		// scroll down to last saved position, then delete from localStorage
+		// note from Ken - this works because we've still got all the articles loaded into the frontend - no need to maintain pagination position
+		if (this.contentsEl.current && localStorage['rss-article-list-scroll-position']) {
+			this.contentsEl.current.scrollTop =
+				localStorage['rss-article-list-scroll-position'];
+			delete localStorage['rss-article-list-scroll-position'];
 		}
 	}
 	getRSSFeed(rssFeedID) {
@@ -217,7 +227,17 @@ class RSSArticleList extends React.Component {
 				rightContents = (
 					<React.Fragment>
 						{sortedArticles.map(article => {
-							return <ArticleListItem key={article._id} {...article} />;
+							return (
+								<ArticleListItem
+									key={article._id}
+									onNavigation={() => {
+										localStorage[
+											'rss-article-list-scroll-position'
+										] = this.contentsEl.current.scrollTop;
+									}}
+									{...article}
+								/>
+							);
 						})}
 
 						{this.state.reachedEndOfFeed ? (
@@ -283,7 +303,9 @@ class RSSArticleList extends React.Component {
 							</div>
 						</div>
 					</div>
-					<div className="list content">{rightContents}</div>
+					<div className="list content" ref={this.contentsEl}>
+						{rightContents}
+					</div>
 				</React.Fragment>
 			);
 		}

--- a/app/src/components/RecentArticlesList.js
+++ b/app/src/components/RecentArticlesList.js
@@ -7,9 +7,22 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 class RecentArticlesList extends React.Component {
+	constructor(props) {
+		super(props);
+		this.contentsEl = React.createRef();
+	}
 	componentDidMount() {
 		getPinnedArticles(this.props.dispatch);
 		getFeed(this.props.dispatch, 'article', 0, 20);
+	}
+	componentWillReceiveProps() {
+		// scroll down to last saved position, then delete from localStorage
+		// note from Ken - this works because we've still got all the articles loaded into the frontend - no need to maintain pagination position
+		if (this.contentsEl.current && localStorage['recent-article-list-scroll-position']) {
+			this.contentsEl.current.scrollTop =
+				localStorage['recent-article-list-scroll-position'];
+			delete localStorage['recent-article-list-scroll-position'];
+		}
 	}
 	render() {
 		return (
@@ -18,9 +31,19 @@ class RecentArticlesList extends React.Component {
 					<h1>Recent Articles</h1>
 				</div>
 
-				<div className="list content">
+				<div className="list content" ref={this.contentsEl}>
 					{this.props.articles.map(article => {
-						return <ArticleListItem key={article._id} {...article} />;
+						return (
+							<ArticleListItem
+								key={article._id}
+								onNavigation={() => {
+									localStorage[
+										'recent-article-list-scroll-position'
+									] = this.contentsEl.current.scrollTop;
+								}}
+								{...article}
+							/>
+						);
 					})}
 				</div>
 			</React.Fragment>


### PR DESCRIPTION
- saving scroll position on `AllArticlesList`, `RecentArticlesList`, and `RSSArticleList` views in `localStorage`
- when those components mount again, they check to see if a previous scroll position was saved, and if so, restore it & clear saved position
- removed some extra `pinArticle` props passed to `ArticleListItem`