### PR TITLE
Opening external links in system browser

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -46,16 +46,27 @@ if (isElectron) {
 	);
 }
 
+const crawlUpDomForAnchorTag = (node, e) => {
+	if (!node) {
+		// if we've reached the top of the DOM
+		return;
+	} else if (node.nodeName === 'A') {
+		const href = node.getAttribute('href');
+		if (href && !href.includes('#/')) {
+			e.preventDefault();
+			window.ipcRenderer.send('open-external-window', href);
+		} else {
+			return;
+		}
+	} else {
+		return crawlUpDomForAnchorTag(node.parentNode, e); // need to pass the click event down through the recursive calls so we can preventDefault if needed
+	}
+};
+
 if (isElectron) {
 	// Electron-specific code
 	document.body.addEventListener('click', e => {
-		if (e.target.nodeName === 'A') {
-			const href = e.target.getAttribute('href');
-			if (!href.includes('#/')) {
-				e.preventDefault();
-				window.ipcRenderer.send('open-external-window', href);
-			}
-		}
+		crawlUpDomForAnchorTag(e.target, e);
 	});
 }
 

--- a/app/src/components/Header.js
+++ b/app/src/components/Header.js
@@ -105,9 +105,11 @@ class Header extends Component {
 			<div className="popover-panel profile-popover">
 				<div className="panel-element user">
 					<div className="avatar">
-						<Avatar height={80} width={80}>
-							{this.props.user._id}
-						</Avatar>
+						<a href="https://gravatar.com">
+							<Avatar height={80} width={80}>
+								{this.props.user._id}
+							</Avatar>
+						</a>
 					</div>
 					<div className="user-info">
 						<span className="name">{this.props.user.name}</span>


### PR DESCRIPTION
- adds an anchor tag back onto the gravatar image in the profile popover
- on electron, listens to all clicks, then crawls up the DOM until an anchor tag is found. if the anchor tag is an external link, `preventDefault()` and open an external window. if not, ignore.
     - (this allows us to open external links for anchor tags that wrap other elements - for example, anchor tags wrapped around image elements in RSS articles.)