### PR TITLE
Feature/throttle failed feeds

### DIFF
--- a/api/src/workers/conductor.js
+++ b/api/src/workers/conductor.js
@@ -33,6 +33,20 @@ const conductor = () => {
 };
 conductor();
 
+// returns a random number from 2**1, 2**2, ..., 2**n-1, 2**n
+// 2 is two time more likely to be returned than 4, 4 than 8 and so until 2**n
+function rand(n=6){
+	const exp = n;
+	let rand = Math.floor(Math.random() * 2**exp);
+	let b;
+	for (b of [...Array(exp).keys()].reverse()) {
+		if (rand >= (2**b)-1) {
+			break;
+		}
+	}
+	return 2**(exp-b);
+}
+
 // conduct does the actual work of scheduling the scraping
 async function conduct() {
 	for (const [publicationType, publicationConfig] of Object.entries(publicationTypes)) {
@@ -55,6 +69,9 @@ async function conduct() {
 					$lte: moment()
 						.subtract(durationInMinutes, 'minutes')
 						.toDate(),
+				},
+				consecutiveScrapeFailures: {
+					$lte: rand(),
 				},
 			})
 			.limit(maxToSchedule);

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Winds",
-  "version": "2.0.314",
+  "version": "2.0.315",
   "description": "Winds is a beatiful open source RSS Reader and Podcast app. Wind 2.0 was created using React/Redux/Node.\nFor more information, visit https://getstream.io/winds/.\nTo contribute or run your own version head over to Github: https://github.com/getstream/winds",
   "private": true,
   "author": "Winds Team <winds@getstream.io>",


### PR DESCRIPTION
Each time a feed fails the parsing step, we increase a failure count and each time parsing is done correctly we reset it to 0. 

In order to keep bad feeds from clogging rss/podcast queues, the conductor now schedules tasks for feeds with `consecutiveFailures < rand()` where `rand()` is a custom random function with this distribution:

![image](https://user-images.githubusercontent.com/88735/41191227-86c01cfa-6bec-11e8-8d69-7c3991cd29aa.png)

50% of the times conductor schedules feeds that failed less than 3 times in a row
25% of the times feeds that failed less than 5 times in a row
....

This approach gives feeds to recover after a long outage (first successful scrape resets the count to 0) and keeps bad feeds away.