### PR TITLE
Enclosure restrictions

### DIFF
--- a/app/src/components/RSSArticle.js
+++ b/app/src/components/RSSArticle.js
@@ -133,13 +133,18 @@ class RSSArticle extends React.Component {
 
 				<div className="content">
 					<div className="enclosures">
-						{this.props.enclosures.map(enclosure => (
-							<ReactPlayer
-								controls={true}
-								key={enclosure._id}
-								url={enclosure.url}
-							/>
-						))}
+						{this.props.enclosures.map(
+							enclosure =>
+								enclosure.type.includes('audio') ||
+								enclosure.type.includes('video') ||
+								enclosure.type.includes('youtube') ? (
+									<ReactPlayer
+										controls={true}
+										key={enclosure._id}
+										url={enclosure.url}
+									/>
+								) : null,
+						)}
 					</div>
 					{articleContents}
 				</div>


### PR DESCRIPTION
- only renders enclosures that include `audio`, `video`, or `youtube` in the `type` field