### PR TITLE
Fix description multi-line issue for linux desktop entry

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -139,6 +139,8 @@
         "snap",
         "AppImage"
       ],
+      "description": "Winds is a beatiful open source RSS Reader and Podcast app",
+      "category": "Network;Feed",
       "publish": {
         "provider": "s3",
         "bucket": "winds-2.0-releases",


### PR DESCRIPTION
### Description of the Change

This fixes #419 (Fail to add desktop entry on Linux). The multi-line value of the "description" key in the "pacakge.json" file was creating the issue. I also set the correct categories (Network, Feed) for the entry.