### PR TITLE
Cursor cleverness - pagination fixes

### DIFF
--- a/app/src/components/AllArticlesList.js
+++ b/app/src/components/AllArticlesList.js
@@ -93,10 +93,10 @@ class AllArticles extends React.Component {
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{"That's it! No more articles here."}</p>
+							<p>{'That\'s it! No more articles here.'}</p>
 							<p>
 								{
-									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
+									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
 								}
 							</p>
 						</div>

--- a/app/src/components/AllArticlesList.js
+++ b/app/src/components/AllArticlesList.js
@@ -21,15 +21,26 @@ class AllArticles extends React.Component {
 		this.contentsEl = React.createRef();
 	}
 	componentDidMount() {
-		this.getArticleFeed();
-		getPinnedArticles(this.props.dispatch);
-		this.subscription = window.streamClient
-			.feed('user_article', this.props.userID, this.props.userArticleStreamToken)
-			.subscribe(() => {
-				this.setState({
-					newArticlesAvailable: true,
-				});
-			});
+		this.setState(
+			{
+				cursor: Math.floor(this.props.articles.length / 10),
+			},
+			() => {
+				this.getArticleFeed();
+				getPinnedArticles(this.props.dispatch);
+				this.subscription = window.streamClient
+					.feed(
+						'user_article',
+						this.props.userID,
+						this.props.userArticleStreamToken,
+					)
+					.subscribe(() => {
+						this.setState({
+							newArticlesAvailable: true,
+						});
+					});
+			},
+		);
 	}
 	componentWillReceiveProps() {
 		// scroll down to last saved position, then delete from localStorage
@@ -82,10 +93,10 @@ class AllArticles extends React.Component {
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{'That\'s it! No more articles here.'}</p>
+							<p>{"That's it! No more articles here."}</p>
 							<p>
 								{
-									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
+									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
 								}
 							</p>
 						</div>

--- a/app/src/components/AllEpisodesList.js
+++ b/app/src/components/AllEpisodesList.js
@@ -45,14 +45,25 @@ class AllEpisodesList extends React.Component {
 	}
 
 	componentDidMount() {
-		this.getEpisodes();
-		this.subscription = window.streamClient
-			.feed('user_episode', this.props.userID, this.props.userEpisodeStreamToken)
-			.subscribe(() => {
-				this.setState({
-					newEpisodesAvailable: true,
-				});
-			});
+		this.setState(
+			{
+				cursor: Math.floor(this.props.episodes.length / 10),
+			},
+			() => {
+				this.getEpisodes();
+				this.subscription = window.streamClient
+					.feed(
+						'user_episode',
+						this.props.userID,
+						this.props.userEpisodeStreamToken,
+					)
+					.subscribe(() => {
+						this.setState({
+							newEpisodesAvailable: true,
+						});
+					});
+			},
+		);
 	}
 	getEpisodes() {
 		getFeed(this.props.dispatch, 'episode', this.state.cursor, 10);
@@ -100,10 +111,10 @@ class AllEpisodesList extends React.Component {
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{'That\'s it! No more episodes here.'}</p>
+							<p>{"That's it! No more episodes here."}</p>
 							<p>
 								{
-									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
+									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
 								}
 							</p>
 						</div>

--- a/app/src/components/AllEpisodesList.js
+++ b/app/src/components/AllEpisodesList.js
@@ -111,10 +111,10 @@ class AllEpisodesList extends React.Component {
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{"That's it! No more episodes here."}</p>
+							<p>{'That\'s it! No more episodes here.'}</p>
 							<p>
 								{
-									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
+									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
 								}
 							</p>
 						</div>


### PR DESCRIPTION
# Problem

- click on "Articles" header or "Recent Articles" panel header, go to "All Articles" view ("All Articles" cursor is reset to 0)
- scroll down a bunch, paginate through 100 articles (load those 100 articles into redux)
- navigate to an individual RSS feed
- click on "Articles" header or "Recent Articles" panel header, go back to "All Articles" view ("All Articles" cursor is reset back to 0)
- 100 articles are already loaded into "All Articles" view, but cursor is at 0, so scrolling to the bottom of the page doesn't do anything - have to scroll up and down until cursor hits 10 and starts getting new articles

# Solution

When "All Articles" view mounts, calculate cursor based on how many articles are already in view - _then_ get new articles from there.

<o/