### PR TITLE
Frontend Analytics

### DIFF
--- a/api/src/models/pin.js
+++ b/api/src/models/pin.js
@@ -49,6 +49,7 @@ export const PinSchema = new Schema(
 					'description',
 					'images',
 					'publicationDate',
+					'link',
 				],
 			},
 		},

--- a/app/package.json
+++ b/app/package.json
@@ -86,6 +86,7 @@
     "react-router-dom": "^4.3.1",
     "react-waypoint": "^8.0.2",
     "redux": "^4.0.0",
+    "stream-analytics": "^2.7.0",
     "video-react": "^0.11.2"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,6 @@
     "eslint-loader": "2.0.0",
     "eslint-plugin-flowtype": "2.49.3",
     "eslint-plugin-import": "2.13.0",
-    "eslint-plugin-jsx-a11y": "6.1.0",
     "eslint-plugin-react": "7.10.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.11",

--- a/app/src/AppRouter.js
+++ b/app/src/AppRouter.js
@@ -31,6 +31,11 @@ class AppRouter extends Component {
 		if (localStorage['authedUser']) {
 			fetch('GET', `/users/${localStorage['authedUser']}`)
 				.then(res => {
+					// set user for stream analytics
+					window.streamAnalyticsClient.setUser({
+						id: res.data._id,
+						alias: res.data.email,
+					});
 					this.props.dispatch({
 						type: 'UPDATE_USER',
 						user: res.data,

--- a/app/src/components/AllEpisodesList.js
+++ b/app/src/components/AllEpisodesList.js
@@ -1,12 +1,12 @@
 import loaderIcon from '../images/loaders/default.svg';
 import Img from 'react-image';
-import fetch from '../util/fetch';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import EpisodeListItem from './EpisodeListItem';
 import Waypoint from 'react-waypoint';
 import { getFeed } from '../util/feeds';
+import { getPinnedEpisodes } from '../util/pins';
 
 class AllEpisodesList extends React.Component {
 	constructor(props) {
@@ -17,39 +17,14 @@ class AllEpisodesList extends React.Component {
 			reachedEndOfFeed: false,
 		};
 	}
-	pinEpisode(episodeID) {
-		fetch('POST', '/pins', {
-			episode: episodeID,
-		})
-			.then(response => {
-				this.props.dispatch({
-					pin: response.data,
-					type: 'PIN_EPISODE',
-				});
-			})
-			.catch(err => {
-				console.log(err); // eslint-disable-line no-console
-			});
-	}
-	unpinEpisode(pinID, episodeID) {
-		fetch('DELETE', `/pins/${pinID}`)
-			.then(() => {
-				this.props.dispatch({
-					episodeID,
-					type: 'UNPIN_EPISODE',
-				});
-			})
-			.catch(err => {
-				console.log(err); // eslint-disable-line no-console
-			});
-	}
-
 	componentDidMount() {
 		this.setState(
 			{
 				cursor: Math.floor(this.props.episodes.length / 10),
 			},
 			() => {
+				// also get pinned episodes
+				getPinnedEpisodes(this.props.dispatch);
 				this.getEpisodes();
 				this.subscription = window.streamClient
 					.feed(
@@ -98,23 +73,17 @@ class AllEpisodesList extends React.Component {
 						return (
 							<EpisodeListItem
 								key={episode._id}
-								pinEpisode={() => {
-									this.pinEpisode(episode._id);
-								}}
 								playable={false}
-								unpinEpisode={() => {
-									this.unpinEpisode(episode.pinID, episode._id);
-								}}
 								{...episode}
 							/>
 						);
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{'That\'s it! No more episodes here.'}</p>
+							<p>{"That's it! No more episodes here."}</p>
 							<p>
 								{
-									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
+									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
 								}
 							</p>
 						</div>

--- a/app/src/components/EpisodeListItem.js
+++ b/app/src/components/EpisodeListItem.js
@@ -6,6 +6,8 @@ import pauseIcon from '../images/icons/pause.svg';
 import playIcon from '../images/icons/play.svg';
 import { withRouter } from 'react-router-dom';
 import TimeAgo from './TimeAgo';
+import { pinEpisode, unpinEpisode } from '../util/pins';
+import { connect } from 'react-redux';
 
 class EpisodeListItem extends React.Component {
 	constructor(props) {
@@ -74,9 +76,13 @@ class EpisodeListItem extends React.Component {
 								e.preventDefault();
 								e.stopPropagation();
 								if (this.props.pinned) {
-									this.props.unpinEpisode();
+									unpinEpisode(
+										this.props.pinID,
+										this.props._id,
+										this.props.dispatch,
+									);
 								} else {
-									this.props.pinEpisode();
+									pinEpisode(this.props._id, this.props.dispatch);
 								}
 							}}
 						>
@@ -123,7 +129,6 @@ EpisodeListItem.propTypes = {
 	images: PropTypes.shape({
 		og: PropTypes.string,
 	}),
-	pinEpisode: PropTypes.func.isRequired,
 	pinned: PropTypes.bool,
 	playOrPauseEpisode: PropTypes.func,
 	playable: PropTypes.bool,
@@ -139,7 +144,6 @@ EpisodeListItem.propTypes = {
 	publicationDate: PropTypes.string,
 	recent: PropTypes.bool,
 	title: PropTypes.string,
-	unpinEpisode: PropTypes.func.isRequired,
 };
 
-export default withRouter(EpisodeListItem);
+export default connect()(withRouter(EpisodeListItem));

--- a/app/src/components/Player.js
+++ b/app/src/components/Player.js
@@ -62,6 +62,14 @@ class Player extends Component {
 			return;
 		} else if (!prevProps.playing && this.props.playing) {
 			if (!prevProps.episode) {
+				window.streamAnalyticsClient.trackEngagement({
+					label: 'episode_listen_start',
+					content: {
+						foreign_id: `episodes:${this.props.episode._id}`,
+					},
+				});
+
+				// just started a new episode - send "listen" engagement
 				// make a request to get the played progress
 				fetch('GET', '/listens', null, { episode: this.props.episode._id }).then(
 					response => {
@@ -83,6 +91,14 @@ class Player extends Component {
 		} else if (prevProps.playing && !this.props.playing) {
 			this.audioPlayerElement.audioEl.pause();
 		} else if (this.props.episode._id !== prevProps.episode._id) {
+			// transitioned from previous episode to new episode - send "listen" engagement
+			window.streamAnalyticsClient.trackEngagement({
+				label: 'episode_listen_start',
+				content: {
+					foreign_id: `episodes:${this.props.episode._id}`,
+				},
+			});
+
 			// check and get the latest listen data for the podcast - set the "duration" field
 			fetch('GET', '/listens', null, { episode: this.props.episode._id }).then(
 				response => {
@@ -151,7 +167,7 @@ class Player extends Component {
 	}
 
 	updateProgress(seconds) {
-		let progress = seconds / this.audioPlayerElement.audioEl.duration * 100;
+		let progress = (seconds / this.audioPlayerElement.audioEl.duration) * 100;
 		this.setState({
 			currentTime: seconds,
 			duration: this.audioPlayerElement.audioEl.duration,
@@ -404,4 +420,7 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Player);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(Player);

--- a/app/src/components/Player.js
+++ b/app/src/components/Player.js
@@ -20,6 +20,7 @@ class Player extends Component {
 		super(props);
 
 		this.state = {
+			episodeListenAnalyticsEventSent: false,
 			playbackSpeed: 1,
 			playing: false,
 			progress: 0,
@@ -91,6 +92,12 @@ class Player extends Component {
 		} else if (prevProps.playing && !this.props.playing) {
 			this.audioPlayerElement.audioEl.pause();
 		} else if (this.props.episode._id !== prevProps.episode._id) {
+			// reset analytics event sent state
+
+			this.setState({
+				episodeListenAnalyticsEventSent: false,
+			});
+
 			// transitioned from previous episode to new episode - send "listen" engagement
 			window.streamAnalyticsClient.trackEngagement({
 				label: 'episode_listen_start',
@@ -317,6 +324,24 @@ class Player extends Component {
 					}}
 					onListen={seconds => {
 						this.updateProgress(seconds);
+
+						// check to see if we should send the analytics event
+						if (
+							!this.state.episodeListenAnalyticsEventSent *
+							(seconds / this.audioPlayerElement.audioEl.duration > 0.8)
+						) {
+							console.log('sending analytics event');
+							window.streamAnalyticsClient.trackEngagement({
+								label: 'episode_listen_complete',
+								content: {
+									foreign_id: `episodes:${this.props.episode._id}`,
+								},
+							});
+
+							this.setState({
+								episodeListenAnalyticsEventSent: true,
+							});
+						}
 
 						// check last sent
 						let currentTime = new Date().valueOf();

--- a/app/src/components/PodcastEpisodesView.js
+++ b/app/src/components/PodcastEpisodesView.js
@@ -40,6 +40,10 @@ class PodcastEpisodesView extends React.Component {
 	}
 
 	componentDidMount() {
+		window.streamAnalyticsClient.trackEngagement({
+			label: 'viewed_podcast',
+			content: `podcast:${this.props.match.params.podcastID}`,
+		});
 		this.props.getPodcast(this.props.match.params.podcastID);
 		this.getEpisodes(this.props.match.params.podcastID);
 		getPinnedEpisodes(this.props.dispatch);
@@ -55,6 +59,10 @@ class PodcastEpisodesView extends React.Component {
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.match.params.podcastID !== this.props.match.params.podcastID) {
 			// essentially, if we've just switched views from one podcast to another
+			window.streamAnalyticsClient.trackEngagement({
+				label: 'viewed_podcast',
+				content: `podcast:${nextProps.match.params.podcastID}`,
+			});
 			this.setState(
 				{
 					episodeCursor: 1, // mongoose-api-query starts pages at 1, not 0
@@ -164,15 +172,15 @@ class PodcastEpisodesView extends React.Component {
 		if (sortedEpisodes.length === 0) {
 			rightColumn = (
 				<div>
-					<p>{'We haven\'t found any episodes for this podcast feed yet :('}</p>
+					<p>{"We haven't found any episodes for this podcast feed yet :("}</p>
 					<p>
 						{
-							'It might be because the podcast feed doesn\'t have any episodes, or because it just got added and we\'re still parsing them. Come check back in a few minutes.'
+							"It might be because the podcast feed doesn't have any episodes, or because it just got added and we're still parsing them. Come check back in a few minutes."
 						}
 					</p>
 					<p>
 						{
-							'If you\'re pretty sure there\'s supposed to be some episodes here, and they aren\'t showing up, please file a '
+							"If you're pretty sure there's supposed to be some episodes here, and they aren't showing up, please file a "
 						}
 						<a href="https://github.com/getstream/winds/issues">
 							GitHub Issue
@@ -196,9 +204,6 @@ class PodcastEpisodesView extends React.Component {
 							<EpisodeListItem
 								active={active}
 								key={episode._id}
-								pinEpisode={() => {
-									this.props.pinEpisode(episode._id);
-								}}
 								playOrPauseEpisode={() => {
 									if (active && this.props.context.playing) {
 										this.props.pauseEpisode();
@@ -220,10 +225,10 @@ class PodcastEpisodesView extends React.Component {
 					})}
 					{this.state.reachedEndOfFeed ? (
 						<div className="end">
-							<p>{'That\'s it! No more episodes here.'}</p>
+							<p>{"That's it! No more episodes here."}</p>
 							<p>
 								{
-									'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
+									"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
 								}
 							</p>
 						</div>
@@ -514,4 +519,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 	};
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PodcastEpisodesView);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(PodcastEpisodesView);

--- a/app/src/components/RSSArticle.js
+++ b/app/src/components/RSSArticle.js
@@ -20,18 +20,28 @@ class RSSArticle extends React.Component {
 	}
 
 	componentDidMount() {
+		window.streamAnalyticsClient.trackEngagement({
+			label: 'article_open',
+			content: {
+				foreign_id: `articles:${this.props.match.params.articleID}`,
+			},
+		});
 		getPinnedArticles(this.props.dispatch);
 		this.getArticle(this.props.match.params.articleID);
-		if (this.props.url) {
-			this.getRSSContent(this.props._id);
-		}
+		this.getRSSContent(this.props.match.params.articleID);
 	}
 
 	componentWillReceiveProps(nextProps) {
-		if (nextProps._id !== this.props._id) {
+		if (nextProps.match.params.articleID !== this.props.match.params.articleID) {
+			window.streamAnalyticsClient.trackEngagement({
+				label: 'article_open',
+				content: {
+					foreign_id: `articles:${nextProps.match.params.articleID}`,
+				},
+			});
 			getPinnedArticles(this.props.dispatch);
 			this.getArticle(nextProps.match.params.articleID);
-			this.getRSSContent(nextProps._id);
+			this.getRSSContent(nextProps.match.params.articleID);
 		}
 	}
 

--- a/app/src/components/RSSArticle.js
+++ b/app/src/components/RSSArticle.js
@@ -41,7 +41,6 @@ class RSSArticle extends React.Component {
 				!this.state.sentArticleReadCompleteAnalyticsEvent &&
 				scrollPercentage > 0.8
 			) {
-				console.log('firing analytics event');
 				window.streamAnalyticsClient.trackEngagement({
 					label: 'article_read_complete',
 					content: {

--- a/app/src/components/RSSArticleList.js
+++ b/app/src/components/RSSArticleList.js
@@ -51,6 +51,12 @@ class RSSArticleList extends React.Component {
 	}
 
 	componentDidMount() {
+		// send analytic event that they viewed a feed
+		window.streamAnalyticsClient.trackEngagement({
+			label: 'viewed_rss_feed',
+			content: `rss:${this.props.match.params.rssFeedID}`,
+		});
+
 		this.getRSSFeed(this.props.match.params.rssFeedID);
 		this.getFollowState(this.props.match.params.rssFeedID);
 		this.getRSSArticles(this.props.match.params.rssFeedID);
@@ -66,6 +72,11 @@ class RSSArticleList extends React.Component {
 	}
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.match.params.rssFeedID !== this.props.match.params.rssFeedID) {
+			window.streamAnalyticsClient.trackEngagement({
+				label: 'viewed_rss_feed',
+				content: `rss:${nextProps.match.params.rssFeedID}`,
+			});
+
 			// if navigating between rss feeds
 			this.setState(
 				{
@@ -238,15 +249,15 @@ class RSSArticleList extends React.Component {
 			if (this.props.articles.length === 0) {
 				rightContents = (
 					<div>
-						<p>{'We haven\'t found any articles for this RSS feed yet :('}</p>
+						<p>{"We haven't found any articles for this RSS feed yet :("}</p>
 						<p>
 							{
-								'It might be because the RSS feed doesn\'t have any articles, or because it just got added and we\'re still parsing them. Come check back in a few minutes?'
+								"It might be because the RSS feed doesn't have any articles, or because it just got added and we're still parsing them. Come check back in a few minutes?"
 							}
 						</p>
 						<p>
 							{
-								'If you\'re pretty sure there\'s supposed to be some articles here, and they aren\'t showing up, please file a '
+								"If you're pretty sure there's supposed to be some articles here, and they aren't showing up, please file a "
 							}
 							<a href="https://github.com/getstream/winds/issues">
 								GitHub Issue
@@ -273,10 +284,10 @@ class RSSArticleList extends React.Component {
 
 						{this.state.reachedEndOfFeed ? (
 							<div className="end">
-								<p>{'That\'s it! No more articles here.'}</p>
+								<p>{"That's it! No more articles here."}</p>
 								<p>
 									{
-										'What, did you think that once you got all the way around, you\'d just be back at the same place that you started? Sounds like some real round-feed thinking to me.'
+										"What, did you think that once you got all the way around, you'd just be back at the same place that you started? Sounds like some real round-feed thinking to me."
 									}
 								</p>
 							</div>

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Raven from 'raven-js';
 import stream from 'getstream';
+import StreamAnalytics from 'stream-analytics';
 
 import packageInfo from '../package.json';
 
@@ -17,6 +18,11 @@ window.streamClient = stream.connect(
 	null,
 	process.env.REACT_APP_STREAM_APP_ID,
 );
+
+window.streamAnalyticsClient = new StreamAnalytics({
+	apiKey: process.env.REACT_APP_STREAM_API_KEY,
+	token: process.env.REACT_APP_STREAM_ANALYTICS,
+});
 
 Raven.context(() => {
 	ReactDOM.render(<App />, document.getElementById('root'));

--- a/app/src/util/pins.js
+++ b/app/src/util/pins.js
@@ -14,6 +14,14 @@ const unpinArticle = (pinID, articleID, dispatch) => {
 };
 
 const pinArticle = (articleID, dispatch) => {
+	// send pin analytic event
+	window.streamAnalyticsClient.trackEngagement({
+		label: 'pinned_article',
+		content: {
+			foreign_id: `articles:${articleID}`,
+		},
+	});
+
 	fetch('POST', '/pins', {
 		article: articleID,
 	})

--- a/app/src/util/pins.js
+++ b/app/src/util/pins.js
@@ -36,6 +36,42 @@ const pinArticle = (articleID, dispatch) => {
 		});
 };
 
+const pinEpisode = (episodeID, dispatch) => {
+	// send pin analytic event
+	window.streamAnalyticsClient.trackEngagement({
+		label: 'pinned_episode',
+		content: {
+			foreign_id: `episodes:${episodeID}`,
+		},
+	});
+
+	fetch('POST', '/pins', {
+		episode: episodeID,
+	})
+		.then(response => {
+			dispatch({
+				pin: response.data,
+				type: 'PIN_EPISODE',
+			});
+		})
+		.catch(err => {
+			console.log(err); // eslint-disable-line no-console
+		});
+};
+
+const unpinEpisode = (pinID, episodeID, dispatch) => {
+	fetch('DELETE', `/pins/${pinID}`)
+		.then(() => {
+			dispatch({
+				episodeID,
+				type: 'UNPIN_EPISODE',
+			});
+		})
+		.catch(err => {
+			console.log(err); // eslint-disable-line no-console
+		});
+};
+
 const getPinnedArticles = dispatch => {
 	fetch('GET', '/pins', null, {
 		type: 'article',
@@ -87,4 +123,11 @@ const getPinnedEpisodes = dispatch => {
 	});
 };
 
-export { pinArticle, unpinArticle, getPinnedArticles, getPinnedEpisodes };
+export {
+	pinArticle,
+	pinEpisode,
+	unpinEpisode,
+	unpinArticle,
+	getPinnedArticles,
+	getPinnedEpisodes,
+};

--- a/app/src/views/auth-views/Create.js
+++ b/app/src/views/auth-views/Create.js
@@ -29,8 +29,13 @@ class Create extends Component {
 		} else {
 			return (
 				<AccountDetailsForm
-					done={(userID, jwt) => {
-						localStorage['authedUser'] = userID;
+					done={({ _id, email, jwt }) => {
+						// set user for stream analytics
+						window.streamAnalyticsClient.setUser({
+							id: _id,
+							alias: email,
+						});
+						localStorage['authedUser'] = _id;
 						localStorage['jwt'] = jwt;
 						this.props.history.push('/');
 					}}
@@ -280,7 +285,7 @@ class AccountDetailsForm extends React.Component {
 				interests: this.props.interests,
 			})
 			.then(res => {
-				this.props.done(res.data._id, res.data.jwt);
+				this.props.done(res.data);
 
 				this.setState({
 					submitting: false,

--- a/app/src/views/auth-views/Login.js
+++ b/app/src/views/auth-views/Login.js
@@ -1,9 +1,8 @@
-import { Link, withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
 import config from '../../config';
-import { connect } from 'react-redux';
 
 class Login extends Component {
 	constructor(props) {
@@ -30,6 +29,12 @@ class Login extends Component {
 				password: this.state.password,
 			})
 			.then(res => {
+				// set user for stream analytics
+				window.streamAnalyticsClient.setUser({
+					id: res.data._id,
+					alias: res.data.email,
+				});
+
 				window.localStorage.setItem('jwt', res.data.jwt);
 				window.localStorage.setItem('authedUser', res.data._id);
 
@@ -115,15 +120,4 @@ Login.propTypes = {
 	signin: PropTypes.func,
 };
 
-const mapDispatchToProps = dispatch => {
-	return {
-		updateUser: user => {
-			dispatch({
-				type: 'UPDATE_USER',
-				user,
-			});
-		},
-	};
-};
-
-export default connect(null, mapDispatchToProps)(withRouter(Login));
+export default Login;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1474,6 +1474,10 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
+"browser-request@git://github.com/matthisk/browser-request.git":
+  version "0.3.2"
+  resolved "git://github.com/matthisk/browser-request.git#253fa31d99bbb4d03bb72e11a5a1c73ccc85ac71"
+
 browser-resolve@^1.11.2:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
@@ -5587,7 +5591,7 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-loader@^0.5.4:
+json-loader@^0.5.3, json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
@@ -8287,7 +8291,7 @@ replace-ext@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-"request@>=2.9.0 <2.82.0":
+request@2.81.0, "request@>=2.9.0 <2.82.0":
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -8968,6 +8972,15 @@ stdout-stream@^1.4.0:
   resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
   dependencies:
     readable-stream "^2.0.1"
+
+stream-analytics@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/stream-analytics/-/stream-analytics-2.7.0.tgz#0b818c0b1ef8586128511a370f69482dfcf2936e"
+  dependencies:
+    browser-request "git://github.com/matthisk/browser-request"
+    json-loader "^0.5.3"
+    request "2.81.0"
+    validate.js "^0.9.0"
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -9790,6 +9803,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate.js@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/validate.js/-/validate.js-0.9.0.tgz#8acf0144f1520a19835c6cc663f45e0836aa56c8"
 
 value-equal@^0.4.0:
   version "0.4.0"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -98,8 +98,8 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
 "@types/node@^8.0.24":
-  version "8.10.20"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
+  version "8.10.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.21.tgz#12b3f2359b27aa05a45d886c8ba1eb8d1a77e285"
 
 Base64@^1.0.1:
   version "1.0.1"
@@ -303,6 +303,10 @@ app-builder-bin@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.10.3.tgz#ab4d7b1a3bf4005dea16bf0b184077b3136f8ae9"
 
+app-builder-bin@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.11.1.tgz#33741167f2873cf76805c9557b62caac8ede017b"
+
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
@@ -329,13 +333,6 @@ argparse@^1.0.7:
 aria-query@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.1.tgz#26cbb5aff64144b0a825be1846e0b16cfa00b11e"
-  dependencies:
-    ast-types-flow "0.0.7"
-    commander "^2.11.0"
-
-aria-query@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
@@ -464,7 +461,7 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
+ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
@@ -527,19 +524,19 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^8.0.0:
-  version "8.6.4"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.6.4.tgz#6bf501de426a3b95973f5d237dbcc9181e9904d2"
+  version "8.6.5"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.6.5.tgz#343f3d193ed568b3208e00117a1b96eb691d4ee9"
   dependencies:
     browserslist "^3.2.8"
-    caniuse-lite "^1.0.30000859"
+    caniuse-lite "^1.0.30000864"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^6.0.23"
     postcss-value-parser "^3.2.3"
 
 aws-sdk@^2.264.1:
-  version "2.268.1"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.268.1.tgz#d4a2152d7d34c52b6d1c7a4809a2672db7f2996a"
+  version "2.272.1"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.272.1.tgz#d81e6c6f3e82d55cf98250650de4c079c89b76b7"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -573,12 +570,6 @@ axios@^0.18.0:
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
-  dependencies:
-    ast-types-flow "0.0.7"
-
-axobject-query@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.1.tgz#05dfa705ada8ad9db993fa6896f22d395b0b0a07"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -1504,12 +1495,13 @@ browserify-cipher@^1.0.0:
     evp_bytestokey "^1.0.0"
 
 browserify-des@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.1.tgz#3343124db6d7ad53e26a8826318712bdc8450f9c"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
     inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
@@ -1602,12 +1594,31 @@ builder-util-runtime@4.4.0, builder-util-runtime@^4.4.0, builder-util-runtime@~4
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@5.13.2, builder-util@^5.13.0, builder-util@^5.13.1, builder-util@^5.13.2:
+builder-util@5.13.2:
   version "5.13.2"
   resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.13.2.tgz#58b43b5b2c4acdeb9d4994b47152acdb111683ea"
   dependencies:
     "7zip-bin" "~4.0.2"
     app-builder-bin "1.10.3"
+    bluebird-lst "^1.0.5"
+    builder-util-runtime "^4.4.0"
+    chalk "^2.4.1"
+    debug "^3.1.0"
+    fs-extra-p "^4.6.1"
+    is-ci "^1.1.0"
+    js-yaml "^3.12.0"
+    lazy-val "^1.0.3"
+    semver "^5.5.0"
+    source-map-support "^0.5.6"
+    stat-mode "^0.2.2"
+    temp-file "^3.1.3"
+
+builder-util@^5.13.0, builder-util@^5.13.1, builder-util@^5.13.2:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.15.0.tgz#e8381a67bfd1de17e45ea9f1dec26317169a30f3"
+  dependencies:
+    "7zip-bin" "~4.0.2"
+    app-builder-bin "1.11.1"
     bluebird-lst "^1.0.5"
     builder-util-runtime "^4.4.0"
     chalk "^2.4.1"
@@ -1713,12 +1724,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000862"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000862.tgz#6c1e296f8bbe5e5ea46f04215e8b90ed8fb9da8d"
+  version "1.0.30000865"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000865.tgz#82ffb64d40f7567620aac02d3a632079689abc6b"
 
-caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000859:
-  version "1.0.30000862"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000862.tgz#7ca14f5079fa8f77ac814fca92d45deb4b7eff9d"
+caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864:
+  version "1.0.30000865"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1727,10 +1738,6 @@ capture-stack-trace@^1.0.0:
 case-sensitive-paths-webpack-plugin@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz#3d29ced8c1f124bf6f53846fb3f5894731fdc909"
-
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1995,7 +2002,7 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.16.x, commander@^2.11.0, commander@^2.15.1, commander@^2.9.0, commander@~2.16.0:
+commander@2.16.x, commander@^2.11.0, commander@^2.15.1, commander@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
@@ -2404,7 +2411,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-damerau-levenshtein@^1.0.0, damerau-levenshtein@^1.0.4:
+damerau-levenshtein@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
 
@@ -2778,41 +2785,9 @@ electron-boilerplate@^1.1.1:
     electron-dynamic-preload "^0.1.4"
     electron-window-state "^4.1.1"
 
-electron-builder-lib@20.19.2:
+electron-builder-lib@20.19.2, electron-builder-lib@~20.19.1:
   version "20.19.2"
   resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.19.2.tgz#1ad1053f8e02c87a5f949fec575fe55a8dff4b8b"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
-    async-exit-hook "^2.0.1"
-    bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
-    builder-util-runtime "4.4.0"
-    chromium-pickle-js "^0.2.0"
-    debug "^3.1.0"
-    ejs "^2.6.1"
-    electron-osx-sign "0.4.10"
-    electron-publish "20.19.0"
-    env-paths "^1.0.0"
-    fs-extra-p "^4.6.1"
-    hosted-git-info "^2.6.1"
-    is-ci "^1.1.0"
-    isbinaryfile "^3.0.2"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    minimatch "^3.0.4"
-    normalize-package-data "^2.4.0"
-    plist "^3.0.1"
-    read-config-file "3.0.2"
-    sanitize-filename "^1.6.1"
-    semver "^5.5.0"
-    stream-json "^1.1.0"
-    sumchecker "^2.0.2"
-    temp-file "^3.1.3"
-
-electron-builder-lib@~20.19.1:
-  version "20.19.1"
-  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.19.1.tgz#5d385130eeff74c192e4ad81b3295264a7899471"
   dependencies:
     "7zip-bin" "~4.0.2"
     app-builder-bin "1.10.3"
@@ -2979,8 +2954,8 @@ electron-remote@^1.3.0:
     xmlhttprequest "^1.8.0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
-  version "1.3.51"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.51.tgz#6a42b49daaf7f22a5b37b991daf949f34dbdb9b5"
+  version "1.3.52"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz#d2d9f1270ba4a3b967b831c40ef71fb4d9ab5ce0"
 
 electron-updater@^2.23.3:
   version "2.23.3"
@@ -3024,7 +2999,7 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emoji-regex@^6.1.0, emoji-regex@^6.5.1:
+emoji-regex@^6.1.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
@@ -3276,19 +3251,6 @@ eslint-plugin-jsx-a11y@5.1.1:
     damerau-levenshtein "^1.0.0"
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
-
-eslint-plugin-jsx-a11y@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.0.tgz#569f6f2d29546cab82cedaa077ec829693b0c42d"
-  dependencies:
-    aria-query "^3.0.0"
-    array-includes "^3.0.3"
-    ast-types-flow "^0.0.7"
-    axobject-query "^2.0.1"
-    damerau-levenshtein "^1.0.4"
-    emoji-regex "^6.5.1"
-    has "^1.0.3"
-    jsx-ast-utils "^2.0.1"
 
 eslint-plugin-react@7.10.0:
   version "7.10.0"
@@ -3878,8 +3840,8 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
 follow-redirects@^1.0.0, follow-redirects@^1.3.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.1.tgz#67a8f14f5a1f67f962c2c46469c79eaec0a90291"
   dependencies:
     debug "^3.1.0"
 
@@ -4029,19 +3991,9 @@ gaze@^1.0.0:
   dependencies:
     globule "^1.0.0"
 
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
-
 get-caller-file@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4342,15 +4294,6 @@ har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
 
-har-validator@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
-  dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    is-my-json-valid "^2.12.4"
-    pinkie-promise "^2.0.0"
-
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
@@ -4432,11 +4375,11 @@ hash-base@^3.0.0:
     safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.4.tgz#8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
   dependencies:
     inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
+    minimalistic-assert "^1.0.1"
 
 hashids@^1.1.1:
   version "1.1.4"
@@ -4503,8 +4446,8 @@ homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.1.tgz#6e4cee78b01bb849dcf93527708c69fdbee410df"
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -5009,20 +4952,6 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
-is-my-ip-valid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
-
-is-my-json-valid@^2.12.4:
-  version "2.17.2"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz#6b2103a288e94ef3de5cf15d29dd85fc4b78d65c"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    is-my-ip-valid "^1.0.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -5084,10 +5013,6 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -5537,6 +5462,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -5664,10 +5593,6 @@ jsonfile@^4.0.0:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 jsonwebtoken@^8.3.0:
   version "8.3.0"
@@ -6028,10 +5953,10 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6225,7 +6150,7 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@jonschlinkert/micromatch#2.2.0:
+"micromatch@github:jonschlinkert/micromatch#2.2.0":
   version "2.2.0"
   resolved "https://codeload.github.com/jonschlinkert/micromatch/tar.gz/5017fd78202e04c684cc31d3c2fb1f469ea222ff"
   dependencies:
@@ -6284,7 +6209,7 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-minimalistic-assert@^1.0.0:
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
 
@@ -6415,7 +6340,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-needle@^2.2.0:
+needle@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
   dependencies:
@@ -6515,12 +6440,12 @@ node-notifier@^5.0.2, node-notifier@^5.2.1:
     which "^1.3.0"
 
 node-pre-gyp@^0.10.0:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz#e8945c20ef6795a20aac2b44f036eb13cf5146e3"
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
-    needle "^2.2.0"
+    needle "^2.2.1"
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"
@@ -6543,8 +6468,8 @@ node-sass-chokidar@^1.3.0:
     stdout-stream "^1.4.0"
 
 node-sass@^4.7.2:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.2.tgz#5e63fe6bd0f2ae3ac9d6c14ede8620e2b8bdb437"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -6561,7 +6486,7 @@ node-sass@^4.7.2:
     nan "^2.10.0"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
-    request "~2.79.0"
+    request "2.87.0"
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
@@ -7642,10 +7567,6 @@ qs@^6.5.1, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-qs@~6.3.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
-
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
@@ -8318,7 +8239,7 @@ request@2.81.0, "request@>=2.9.0 <2.82.0":
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.45.0, request@^2.78.0, request@^2.79.0, request@^2.85.0, request@^2.86.0:
+request@2.87.0, request@^2.45.0, request@^2.78.0, request@^2.79.0, request@^2.85.0, request@^2.86.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -8342,31 +8263,6 @@ request@^2.45.0, request@^2.78.0, request@^2.79.0, request@^2.85.0, request@^2.8
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
-
-request@~2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -9512,10 +9408,6 @@ tunnel-agent@*, tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel-agent@~0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -9542,8 +9434,8 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 uglify-js@3.4.x, uglify-js@^3.0.13:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.3.tgz#a4fd757b6f34a95f717f7a7a0dccafcaaa60cf7f"
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.4.tgz#92e79532a3aeffd4b6c65755bdba8d5bad98d607"
   dependencies:
     commander "~2.16.0"
     source-map "~0.6.1"
@@ -10158,9 +10050,9 @@ xmldom@0.1.x:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
-"xmlhttp-request@https://github.com/GetStream/xmlhttp-request#2474db1c2829697bcf2788fee49156b62ad8bcfd":
+"xmlhttp-request@git+https://github.com/GetStream/xmlhttp-request.git#2474db1c2829697bcf2788fee49156b62ad8bcfd":
   version "0.4.0"
-  resolved "https://github.com/GetStream/xmlhttp-request#2474db1c2829697bcf2788fee49156b62ad8bcfd"
+  resolved "git+https://github.com/GetStream/xmlhttp-request.git#2474db1c2829697bcf2788fee49156b62ad8bcfd"
 
 xmlhttprequest@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
# Note - an additional `REACT_APP_STREAM_ANALYTICS` var needs to be added before this PR is deployed. 

(Check the most recent PR on the internal secrets repo.)

This PR adds the following analytics events to the frontend:

- user opens an article
- user scrolls 80% of the way through an article
- user starts playing an episode (or the next episode in a sequence starts playing)
- user listens to at least 80% of the episode
- user pins an article
- user pins and episode
- user views the list of articles in an rss feed
- user views the list of episodes in a podcast

This PR **does not** include analytics events for a user clicking the "view on site" external link on articles and episodes - slightly more complicated, decided to save that for later.

Several other small changes:

- removes jsx-a11y, an eslint plugin that was causing some complications
- refactored pin functionality for episodes
- fixes a small bug where external link information wasn't included in pinned episode response