### PR TITLE
feature/redis-queue-flags

### DIFF
--- a/api/src/controllers/rss.js
+++ b/api/src/controllers/rss.js
@@ -79,10 +79,10 @@ exports.post = async (req, res) => {
 			continue;
 		}
 
-		let rss;
-		rss = await RSS.findOne({ feedUrl: feedUrl });
+		let rss = await RSS.findOne({ feedUrl: feedUrl });
+		const limit = moment().subtract(30, 'seconds');
 		// don't update featured RSS feeds since that ends up removing images etc
-		if (!rss || (rss && !rss.featured)) {
+		if (!rss || (!rss.featured && limit.isAfter(rss.lastScraped))) {
 			let response = await RSS.findOneAndUpdate(
 				{ feedUrl: feedUrl },
 				{

--- a/api/src/models/podcast.js
+++ b/api/src/models/podcast.js
@@ -46,20 +46,6 @@ export const PodcastSchema = new Schema(
 			type: Boolean,
 			default: false,
 		},
-		queueState: {
-			isParsing: {
-				type: Boolean,
-				default: false,
-			},
-			isUpdatingOG: {
-				type: Boolean,
-				default: false,
-			},
-			isSynchronizingWithStream: {
-				type: Boolean,
-				default: false,
-			},
-		},
 		images: {
 			featured: {
 				type: String,

--- a/api/src/models/rss.js
+++ b/api/src/models/rss.js
@@ -108,24 +108,6 @@ export const RSSSchema = new Schema(
 			default: '',
 			index: true,
 		},
-		queueState: {
-			isParsing: {
-				type: Boolean,
-				default: false,
-			},
-			isUpdatingOG: {
-				type: Boolean,
-				default: false,
-			},
-			isFetchingSocialScore: {
-				type: Boolean,
-				default: false,
-			},
-			isSynchronizingWithStream: {
-				type: Boolean,
-				default: false,
-			},
-		},
 		language: {
 			type: String,
 			default: '',

--- a/api/src/parsers/feed.js
+++ b/api/src/parsers/feed.js
@@ -205,6 +205,8 @@ export function ReadURL(url) {
 	};
 	return request({
 		method: 'get',
+		agent: false,
+		pool: { maxSockets: 256 },
 		uri: url,
 		timeout: 12 * 1000,
 		headers: headers,

--- a/api/src/utils/queue.js
+++ b/api/src/utils/queue.js
@@ -1,0 +1,86 @@
+import Redis from 'ioredis';
+
+import config from '../config';
+
+const redis = new Redis(config.cache.uri);
+
+const TTL = 3600; // 1 hour in seconds
+
+redis.defineCommand('getQueueFlagSetMembers', {
+	numberOfKeys: 1,
+	lua: `
+		local set = KEYS[1]
+
+		redis.replicate_commands()
+
+		local time = redis.call('TIME')
+		local now = tonumber(time[1])
+
+		redis.call('ZREMRANGEBYSCORE', set, 0, now)
+		return redis.call('ZRANGE', set, 0, -1)
+	`
+});
+
+redis.defineCommand('tryAddToQueueFlagSet', {
+	numberOfKeys: 1,
+	lua: `
+		local key = ARGV[1]
+		local set = KEYS[1]
+
+		redis.replicate_commands()
+
+		local TTL = ${TTL}
+		local time = redis.call('TIME')
+		local now = tonumber(time[1])
+
+		local exists = redis.call('ZSCORE', set, key)
+		if not exists then
+			return redis.call('ZADD', set, now + TTL, key)
+		end
+		return nil
+	`
+});
+
+redis.defineCommand('tryCreateQueueFlag', {
+	numberOfKeys: 1,
+	lua: `
+		local key = KEYS[1]
+
+		redis.replicate_commands()
+
+		local exists = redis.call('EXISTS', key)
+		if exists == 0 then
+			return redis.call('SETEX', key, ${TTL}, 1)
+		end
+		return nil
+	`
+});
+
+export async function tryAddToQueueFlagSet(queueName, suffix, id) {
+	const key = `queue-status:${queueName}`;
+	const value = `${id}:${suffix}`;
+	const created = await redis.tryAddToQueueFlagSet(key, value);
+	return !!created;
+}
+
+export async function removeFromQueueFlagSet(queueName, suffix, id) {
+	const key = `queue-status:${queueName}`;
+	const value = `${id}:${suffix}`;
+	return await redis.zrem(key, value);
+}
+
+export async function getQueueFlagSetMembers(queueName) {
+	const key = `queue-status:${queueName}`;
+	return await redis.getQueueFlagSetMembers(key);
+}
+
+export async function tryCreateQueueFlag(queueName, suffix, id) {
+	const key = `queue-status:${queueName}:${id}:${suffix}`;
+	const created = await redis.tryCreateQueueFlag(key);
+	return !!created;
+}
+
+export async function removeQueueFlag(queueName, suffix, id) {
+	const key = `queue-status:${queueName}:${id}:${suffix}`;
+	return await redis.del(key);
+}

--- a/api/src/workers/og.js
+++ b/api/src/workers/og.js
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 import db from '../utils/db';
 import logger from '../utils/logger';
 import { startSampling } from '../utils/watchdog';
+import { removeQueueFlag } from '../utils/queue';
 import RSS from '../models/rss'; // eslint-disable-line
 import Podcast from '../models/podcast'; // eslint-disable-line
 import Article from '../models/article';
@@ -83,7 +84,7 @@ export async function handleOg(job) {
 	const field = jobType === 'episode' ? 'link' : 'url';
 	const parentField = mongoParentSchema === RSS ? 'rss' : 'podcast';
 
-	await mongoParentSchema.update({ _id: job.data[parentField] }, { "queueState.isUpdatingOG": false });
+	await removeQueueFlag('og', parentField, job.data[parentField]);
 
 	const urls = job.data.urls || [job.data.url];
 	const unecapedUrls = originalPayload.urls || [originalPayload.url];

--- a/api/src/workers/social.js
+++ b/api/src/workers/social.js
@@ -11,6 +11,7 @@ import { timeIt } from '../utils/statsd';
 import { fetchSocialScore } from '../utils/social';
 import { ensureEncoded } from '../utils/urls';
 import { startSampling } from '../utils/watchdog';
+import { removeQueueFlag } from '../utils/queue';
 
 if (require.main === module) {
 	logger.info('Starting the Social worker');
@@ -74,7 +75,7 @@ export async function handleSocial(job) {
 		return;
 	}
 
-	await RSS.update({ _id: job.data.rss }, { "queueState.isSynchronizingWithStream": false });
+	await removeQueueFlag('social', 'rss', job.data.rss);
 
 	let updatingSocialScore = false;
 	await timeIt('winds.handle_social.update_social_score', () => {

--- a/api/src/workers/stream.js
+++ b/api/src/workers/stream.js
@@ -9,6 +9,7 @@ import logger from '../utils/logger';
 import { ProcessStreamQueue, ShutDownStreamQueue } from '../asyncTasks';
 import { timeIt } from '../utils/statsd';
 import { sendFeedToCollections } from '../utils/collections';
+import { removeQueueFlag } from '../utils/queue';
 import { startSampling } from '../utils/watchdog';
 
 if (require.main === module) {
@@ -51,7 +52,7 @@ export async function handleStream(job) {
 	const type = 'rss' in job.data ? 'rss' : 'podcast';
 	const model = 'rss' in job.data ? RSS : Podcast;
 
-	await model.update({ _id: job.data[type] }, { "queueState.isSynchronizingWithStream": false });
+	await removeQueueFlag('stream', type, job.data[type]);
 
 	const feed = await model.findById(job.data[type]);
 	await timeIt('winds.handle_stream.send_to_collections', () => sendFeedToCollections(type, feed));

--- a/api/test/controllers/rss.js
+++ b/api/test/controllers/rss.js
@@ -85,7 +85,7 @@ describe('RSS controller', () => {
 			expect(response).to.have.status(201);
 			expect(response.body).to.have.length(1);
 			expect(response.body[0].url).to.eq('https://news.ycombinator.com');
-			rss = await RSS.find({ url: 'https://news.ycombinator.com' });
+			rss = await RSS.findOne({ url: 'https://news.ycombinator.com' });
 		});
 
 		it('2nd time shoudl still return a response', async () => {
@@ -97,9 +97,9 @@ describe('RSS controller', () => {
 			expect(response).to.have.status(201);
 			expect(response.body).to.have.length(1);
 
-			let rss2 = await RSS.find({ url: 'https://news.ycombinator.com' });
+			const rss2 = await RSS.findOne({ url: 'https://news.ycombinator.com' });
 			// but not be updated
-			expect(rss2.updatedAt).to.eq(rss.updatedAt);
+			expect(Number(rss2.updatedAt)).to.eq(Number(rss.updatedAt));
 		});
 
 		it('creates 2 RSS feeds for Tech Crunch', async () => {

--- a/api/test/data/og/bildblog.html
+++ b/api/test/data/og/bildblog.html
@@ -1,0 +1,738 @@
+<!DOCTYPE html>
+<!--[if IE 7 | IE 8]>
+<html class="ie" lang="en-US">
+<![endif]-->
+<!--[if (gte IE 9) | !(IE)]><!-->
+<html lang="de-DE">
+<!--<![endif]-->
+<head>
+
+<meta name="description" content="Ein Watchblog für deutsche Medien" />
+<meta name="keywords" content="BILD, Bild, watchblog, Bild Blog, Bild-Zeitung" />
+<meta name="verify-v1" content="PP/7GfTAB4s4EgdLtJmI+uIBLnR5ZNo4wihMFGkJ7AA=" />
+<meta name="referrer" content="no-referrer">
+
+<link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="/feed/" />
+<link rel="alternate" type="application/xml" title="RSS .92" href="/feed/" />
+<link rel="alternate" type="application/atom+xml" title="Atom 0.3" href="/feed/" />
+
+
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+
+	<title>
+		Exklusives Fake-Interview, Macht und Deutungshoheit, Heidis Abgründe &mdash; BILDblog	</title>
+
+	<link rel="pingback" href="https://bildblog.de/xmlrpc.php" />
+
+			<script type="text/javascript">
+		/* Google Analytics Opt-Out WordPress by WP-Buddy | https://wp-buddy.com/products/plugins/google-analytics-opt-out */
+				var gaoop_property    = 'UA-382311-1';
+		var gaoop_disable_str = 'ga-disable-' + gaoop_property;
+		if ( document.cookie.indexOf( gaoop_disable_str + '=true' ) > -1 ) {
+			window[ gaoop_disable_str ] = true;
+		}
+
+		function gaoop_analytics_optout() {
+			document.cookie             = gaoop_disable_str + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+			window[ gaoop_disable_str ] = true;
+			alert('Alles klar. Wir haben einen Cookie gesetzt, damit Google Analytics bei Deinem nächsten Besuch auf unserer Seite keine Daten mehr sammelt.');		}
+			</script>
+	<link rel='dns-prefetch' href='//advice-ads-cdn.vice.com' />
+<link rel='dns-prefetch' href='//ajax.googleapis.com' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel="alternate" type="application/rss+xml" title="BILDblog &raquo; Feed" href="https://bildblog.de/feed/" />
+<link rel="alternate" type="application/rss+xml" title="BILDblog &raquo; Kommentar-Feed" href="https://bildblog.de/comments/feed/" />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.4\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.4\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/bildblog.de\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.9.6"}};
+			!function(a,b,c){function d(a,b){var c=String.fromCharCode;l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,a),0,0);var d=k.toDataURL();l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,b),0,0);var e=k.toDataURL();return d===e}function e(a){var b;if(!l||!l.fillText)return!1;switch(l.textBaseline="top",l.font="600 32px Arial",a){case"flag":return!(b=d([55356,56826,55356,56819],[55356,56826,8203,55356,56819]))&&(b=d([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]),!b);case"emoji":return b=d([55357,56692,8205,9792,65039],[55357,56692,8203,9792,65039]),!b}return!1}function f(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var g,h,i,j,k=b.createElement("canvas"),l=k.getContext&&k.getContext("2d");for(j=Array("flag","emoji"),c.supports={everything:!0,everythingExceptFlag:!0},i=0;i<j.length;i++)c.supports[j[i]]=e(j[i]),c.supports.everything=c.supports.everything&&c.supports[j[i]],"flag"!==j[i]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[j[i]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(h=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",h,!1),a.addEventListener("load",h,!1)):(a.attachEvent("onload",h),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),g=c.source||{},g.concatemoji?f(g.concatemoji):g.wpemoji&&g.twemoji&&(f(g.twemoji),f(g.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='frank_stylesheet-css'  href='https://bildblog.de/wp-content/themes/Frank-advice/style.css?ver=0.9' type='text/css' media='all' />
+<!--[if IE]>
+<link rel='stylesheet' id='frank_stylesheet_ie-css'  href='https://bildblog.de/wp-content/themes/Frank-advice/ie.css?ver=0.9' type='text/css' media='all' />
+<![endif]-->
+<link rel='stylesheet' id='tf-compiled-options-advice-wp-css'  href='https://bildblog.de/wp-content/uploads/titan-framework-advice-wp-css.css?ver=4.9.6' type='text/css' media='all' />
+<link rel='stylesheet' id='contact-form-7-css'  href='https://bildblog.de/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=5.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='jquery-ui-style-css'  href='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/ui-darkness/jquery-ui.css?ver=4.9.6' type='text/css' media='all' />
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var s2_script_strings = {"ajaxurl":"https:\/\/bildblog.de\/wp-admin\/admin-ajax.php","title":"Diese Seite abonnieren"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://bildblog.de/wp-content/plugins/subscribe2/include/s2_ajax.min.js?ver=1.0'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-content/plugins/google-analyticator/external-tracking.min.js?ver=6.5.4'></script>
+<link rel='https://api.w.org/' href='https://bildblog.de/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://bildblog.de/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://bildblog.de/wp-includes/wlwmanifest.xml" /> 
+<link rel='prev' title='Hitzacker: Polizei-Nachplapperei und Steineschmeißer aus dem Archiv' href='https://bildblog.de/98573/hitzacker-polizei-nachplapperei-und-steineschmeisser-aus-dem-archiv/' />
+<link rel='next' title='Überhitzacker, Der gekränkte Mann, Die DSGVO und das Blogsterben' href='https://bildblog.de/98678/ueberhitzacker-der-gekraenkte-mann-die-dsgvo-und-das-blogsterben/' />
+<meta name="generator" content="WordPress 4.9.6" />
+<link rel="canonical" href="https://bildblog.de/98635/exklusives-fake-interview-macht-und-deutungshoheit-heidis-abgruende/" />
+<link rel='shortlink' href='https://bildblog.de/?p=98635' />
+<link rel="alternate" type="application/json+oembed" href="https://bildblog.de/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fbildblog.de%2F98635%2Fexklusives-fake-interview-macht-und-deutungshoheit-heidis-abgruende%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://bildblog.de/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fbildblog.de%2F98635%2Fexklusives-fake-interview-macht-und-deutungshoheit-heidis-abgruende%2F&#038;format=xml" />
+<style type="text/css">/** Google Analytics Opt Out Custom CSS **/.gaoop {color: #ffffff; line-height: 2; position: fixed; bottom: 0; left: 0; width: 100%; -webkit-box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4); -moz-box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4); box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4); background-color: #0E90D2; padding: 0; margin: 0; } .gaoop a {color: #67C2F0; text-decoration: none; } .gaoop a:hover {color: #ffffff; text-decoration: underline; } .gaoop-info-icon {position: relative; margin: 0; padding: 0; text-align: center; vertical-align: top; display: inline-block; width: 5%; } .gaoop-close-icon {position: relative; opacity: 0.5; ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; filter: alpha(opacity=50); -moz-opacity: 0.5; -khtml-opacity: 0.5; margin: 0; padding: 0; text-align: center; vertical-align: top; display: inline-block; width: 5%; } .gaoop-close-icon:hover {z-index: 1; opacity: 1; ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter: alpha(opacity=100); -moz-opacity: 1; -khtml-opacity: 1; } .gaoop_closed .gaoop-opt-out-link, .gaoop_closed .gaoop-close-icon {display: none; } .gaoop_closed {width: 55px; right: 0; left: auto; opacity: 0.5; ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; filter: alpha(opacity=50); -moz-opacity: 0.5; -khtml-opacity: 0.5; } .gaoop_closed:hover {opacity: 1; ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter: alpha(opacity=100); -moz-opacity: 1; -khtml-opacity: 1; } .gaoop_closed .gaoop-opt-out-content {display: none; } .gaoop_closed .gaoop-info-icon {width: 100%; } .gaoop-opt-out-content {display: inline-block; width: 90%; vertical-align: top; } </style><link rel='stylesheet' id='pagebar-stylesheet-css'  href='https://bildblog.de/wp-content/themes/Frank-advice/pagebar.css?ver=4.9.6' type='text/css' media='all' />
+<!--[if lt IE 9]><script src="https://bildblog.de/wp-content/themes/Frank-advice/javascripts/html5.js"></script><![endif]--><!--[if lt IE 7]><script src="https://bildblog.de/wp-content/themes/Frank-advice/javascripts/ie7.js"></script><![endif]--><!-- Google Analytics Tracking by Google Analyticator 6.5.4: http://www.videousermanuals.com/google-analyticator/ -->
+<script type="text/javascript">
+    var analyticsFileTypes = [''];
+    var analyticsSnippet = 'disabled';
+    var analyticsEventTracking = 'enabled';
+</script>
+<script type="text/javascript">
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-382311-1', 'auto');
+
+	ga('set', 'anonymizeIp', true);
+ 
+	ga('send', 'pageview');
+</script>
+
+	<script src="https://use.typekit.net/hze0sqe.js"></script>
+	<script>try{Typekit.load({ async: true });}catch(e){}</script>
+
+<script defer src="https://vice-publishers-cdn.vice.com/GENERATED/bildblog.de.js"></script>
+
+<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
+<script>
+window.addEventListener("load", function(){
+window.cookieconsent.initialise({
+  "palette": {
+    "popup": {
+      "background": "#515151"
+    },
+    "button": {
+      "background": "#da3734"
+    }
+  },
+  "theme": "classic",
+  "position": "bottom-left",
+  "content": {
+    "message": "Das BILDblog nutzt Cookies und Google Analytics. Weitere Infos und ein Opt-Out findest Du in unserer",
+    "dismiss": "Alles klar!",
+    "link": "Datenschutzerklärung.",
+    "href": "https://bildblog.de/datenschutz/"
+  }
+})});
+</script>
+
+</head>
+<body id="page" class="post-template-default single single-post postid-98635 single-format-standard">
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-382311-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+	<!--[if lt IE 9]>
+		<div class="chromeframe">Your browser is out of date. Please <a href="http://browsehappy.com/">upgrade your browser </a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a>.</div>
+	<![endif]-->
+
+
+<div class="container">
+
+
+	<header id="page-header" class="row">
+		<a id="advice-logo" href="http://advice.vice.com/"><img src="/wp-content/themes/Frank-advice/ADVICE_LOGO_12.png" width="75"></a>
+
+
+		<hgroup id="site-title-description">
+		</hgroup>
+
+		<div class="kopfzeileaussen">
+
+		<div class="kopfzeile"><a href="https://bildblog.de/">
+							<img src="/bildblogheader.png" alt="BILDblog - Kritisches über deutsche Medien seit 2014" />
+		</a></div></div>
+
+		<nav id="site-nav">
+
+		</nav>
+		
+	</header>
+<div id="content" class="single">
+	<div class="row">
+		<main id="content-primary" role="main">
+									<article itemscope itemtype="http://schema.org/BlogPosting" class="post leftaside">
+				<header class="post-header">
+								<div class="dachzeile"><b><a href="https://bildblog.de/ressort/6-vor-9/">6 vor 9</a></b>&nbsp;&nbsp;</div>	
+					<h1 class="post-title">Exklusives Fake-Interview, Macht und Deutungshoheit, Heidis Abgründe</h1>
+				</header>
+								<div id='content-main' class='row'>
+					<section class='post-content clearfix'>
+												<p><a href="https://www.dwdl.de/nachrichten/67058/tv_movie_erfindet_exklusivinterview_mit_tatortstars/" rel="noopener" target="_blank"><strong>1. &#8222;TV Movie&#8220; erfindet Exklusiv-Interview mit &#8222;Tatort&#8220;-Stars</strong></a><br />
+<em>(dwdl.de, Thomas Lückerath)</em><br />
+Die aktuelle &#8222;TV Movie&#8220; wirbt mit einem &#8222;Exklusiv-Interview&#8220; mit den &#8222;Tatort“-Kommissaren Jan Josef Liefers und Axel Prahl, doch einiges spricht dafür, dass das Gespräch nie stattgefunden hat: Das „Interview“ besteht aus bekannten Textschnipseln und auch die Agentur der beiden Schauspieler weiß von keinem Gespräch. „DWDL“ hat die Bauer Media Group um eine Stellungnahme gebeten. Dort hat man sich 26 Stunden später die folgenden sibyllinischen Worte abgerungen: „Wir sind davon ausgegangen, dass diese Veröffentlichung ordnungsgemäß erfolgt ist. In der Kürze der Zeit können wir leider nicht mehr zu diesem Thema sagen“.<img src="https://ssl-vg03.met.vgwort.de/na/5e55f01fec3e4c9b888ddecae8b58a65" width="1" height="1" alt=""></p>
+<p><a href="http://www.horizont.net/medien/nachrichten/Nach-Partnerschaft-von-Dumont-und-Madsack-FR-Miteigentuemer-Schoeningh-Unsere-Gespraechspartner-sitzen-jetzt-in-Hannover-167194" rel="noopener" target="_blank"><strong>2. FR-Miteigentümer Schöningh: &#8222;Unsere Gesprächspartner sitzen jetzt in Hannover&#8220;</strong></a><br />
+<em>(horizont.net, Ulrike Simon)</em><br />
+Bereits am Mittwoch schrieb Uwe Vorkötter über die „gemeinsame Sache“ der Medienhäuser DuMont und Madsack, die in Wirklichkeit eine Kapitulation DuMonts sei (<a href="http://www.horizont.net/medien/kommentare/DuMont-und-Madsack-Koelsche-Kapitulation--167178" rel="noopener" target="_blank">Kölsche Kapitulation</a>, horizont.net). Nun beschäftigt sich Ulrike Simon mit den möglichen Auswirkungen auf die „Frankfurter Rundschau“.</p>
+<p><a href="http://www.nordbayern.de/politik/der-fall-asef-n-es-geht-um-macht-und-deutungshoheit-1.7618859" rel="noopener" target="_blank"><strong>3. Der Fall Asef N.: &#8222;Es geht um Macht und Deutungshoheit&#8220;</strong></a><br />
+<em>(nordbayern.de, Hans-Peter Kastenhuber)</em><br />
+Rund ein Jahr ist es her, dass ein Berufsschullehrer bei den „Nürnberger Nachrichten“ anruft und aufgeregt von einer Polizeiaktion an seiner Schule berichtet. Eine Redakteurin fährt sofort zum Ort des Geschehens und erlebt, wie ein abgelehnter 21-jähriger Asylbewerber aus Afghanistan auf rabiate Weise festgenommen wird. Als sie Tags darauf in der Zeitung die hässlichen Begleitumstände des brutalen Polizeieinsatzes erwähnt, wird sie angefeindet und teilweise übel beleidigt. Mit ihrer Wahrnehmung ist die Journalistin jedoch nicht alleine: Auch ein anwesender Dekan und ein Pressefotograf sind entsetzt. Doch Polizei und CSU-Landesregierung verkünden ihre eigene Wahrheit und begründen den Einsatz mit einer angeblichen Unterwanderung der protestierenden Schüler durch &#8222;militante Abschiebegegner&#8220; und linke Chaoten.</p>
+<p><a href="https://markheywinkel.de/so-setzen-sieben-deutsche-publisher-facebook-gruppen-ein" rel="noopener" target="_blank"><strong>4. So setzen sieben deutsche Publisher Facebook-Gruppen ein</strong></a><br />
+<em>(markheywinkel.de)</em><br />
+Der Journalist Mark Heywinkel hat sich umgehört, ob Medien nach Facebooks Änderung des Newsfeeds und Herunterstufung von Seiteninhalten nun verstärkt auf Facebook-Gruppen setzen und wie sie dabei verfahren. Seine zusammengetragenen Erfahrungsberichte ergeben ein interessantes Stimmungsbild: Es ist nicht einfach, aber zumindest alle sind dabei.</p>
+<p><a href="http://www.sueddeutsche.de/medien/finale-von-gntm-heidi-ist-der-haeuptling-im-macho-dorf-1.3991514" rel="noopener" target="_blank"><strong>5. Heidi ist der Häuptling im Macho-Dorf</strong></a><br />
+<em>(sueddeutsche.de, Carolin Gasteiger)</em><br />
+Viele Menschen schauen sich auch heutzutage das bereits 13 Jahre alte TV-Format &#8222;Germany&#8217;s Next Topmodel&#8220; (GNTM) an. Dabei gehöre dieser „Abgrund an Menschenfeindlichkeit“ abgeschafft, wie Carolin Gasteiger fordert. Wer einschalte, mache sich mitschuldig: „Man kann GNTM im Jahr 2018 aber nicht mehr ansehen ohne eine Haltung dazu zu entwickeln. Ohne sich einzugestehen, wie ungeniert junge Mädchen ausgenutzt und vorgeführt werden. Ohne zu erkennen, wie falsch und überholt dieses Format ist.“</p>
+<p><a href="https://www.zeit.de/amp/2018/22/william-cohn-neo-magazin-royale-buch-gutes-benehmen?__twitter_impression=true" rel="noopener" target="_blank"><strong>6. Küss die Hand</strong></a><br />
+<em>(zeit.de, Francesco Giammarco)</em><br />
+Zuschauer des „Neo Magazin Royale“ kennen William Cohn als den onkelhaften Typ mit den quietschigen Pullovern  und der tiefen Märchenerzähler-Stimme. Wer ist dieser Cohn? Francesco Giammarco hat sich mit ihm während einer S-Bahn-Fahrt durch Berlin unterhalten.</p>
+											</section>
+					<div class='post-info'>
+						<ul class="metadata vertical">
+	<li class="date"><time datetime="2018-05-25" itemprop="datePublished">25.5.2018, 8:54</time></li>
+
+	<li class='author'>
+		Lorenz Meyer	</li>
+	
+<div style="border: 1px solid #dddddd; margin: 3px 0px 10px 10px; padding: 7px; background: #ececec none repeat scroll 0% 0%; width:90%; float: right; font-size: 0.9em; line-height: 1.3em; color: #4382cf; text-align:right;">
+
+<strong>6 vor 9</strong><br />
+Um 6 Minuten vor 9 Uhr erscheinen hier montags bis freitags handverlesene Links zu lesenswerten Geschichten aus alten und neuen Medien. Tipps gerne bis 8 Uhr an <a style="color: #4382cf;" href="mailto:6vor9@bildblog.de">6vor9<wbr>@bildblog.de</a></div>
+	
+	
+	
+	</ul>																							</div>					
+				</div>
+							</article>
+					</main>
+		 <aside id="sidebar" role="complementary"> 
+
+	
+	<div style="margin:10px 0;"><a href="https://www.facebook.com/BILDblog"><img src="/facebook_icon.png"></a><a href="https://twitter.com/bildblog"><img style="margin-left:5px;" src="/twitter_icon.png"></a><a href="/feed/"><img style="margin-left:5px;" src="/rss_icon.png"></div></a>
+
+<div class="navimenu">
+	<ul>
+		<li><a href="/haeufig-gestellte-fragen/">Was passiert hier?</a></li>
+		<li><a href="/?page_id=1990">Sachdienliche Hinweise?</a></li>
+		<li><a href="/werben-auf-bildblog/">Werben auf BILDblog</a></li>
+		<li><a href="/bildblog-unterstuetzen/">BILDblog unterstützen</a></li>
+	</ul>
+</div>
+
+<div style="margin-top:10px;margin-bottom:10px;">
+     <form method="get" id="searchform" action="/" role="search">
+	<input type="text" placeholder="Suchen"  class='textinput' name="s" id="s" />
+</form>
+
+        <div class="ressortauswahl">
+             <select  name='cat' id='cat' class='postform' >
+	<option value='-1'>Suche nach Medium</option>
+	<option class="level-0" value="1034">20 Minuten&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1005">20min.ch&nbsp;&nbsp;(17)</option>
+	<option class="level-0" value="900">3sat&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1079">Aachener Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="942">abendblatt.de&nbsp;&nbsp;(25)</option>
+	<option class="level-0" value="259">Abendzeitung&nbsp;&nbsp;(7)</option>
+	<option class="level-0" value="1153">abendzeitung-muenchen.de&nbsp;&nbsp;(6)</option>
+	<option class="level-0" value="1152">abendzeitung-nuernberg.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="979">abendzeitung.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1201">ADAC Motorwelt&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1163">Advent 2011&nbsp;&nbsp;(25)</option>
+	<option class="level-0" value="1246">AfD&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="483">AFP&nbsp;&nbsp;(38)</option>
+	<option class="level-0" value="1237">aktuell für die Frau&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1060">Alle Jahre wieder&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1240">Allgemeine Zeitung&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1276">Allgemeine Zeitung (Namibia)&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1247">Alternative für Deutschland&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="451">AP&nbsp;&nbsp;(17)</option>
+	<option class="level-0" value="104">ARD&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1063">Ärztezeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1065">Augsburger Allgemeine&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1094">augsburger-allgemeine.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1070">Auto Bild&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1192">Axel-Springer-Akademie&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1404">Axel-Springer-Verlag&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="378">B.Z.&nbsp;&nbsp;(47)</option>
+	<option class="level-0" value="1281">Bauer Media Group&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1084">Bayern 3&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1342">bayern.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1146">Bayernkurier&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1066">bazonline.ch&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1398">BBC&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1417">Bento&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="380">Berliner Kurier&nbsp;&nbsp;(29)</option>
+	<option class="level-0" value="993">Berliner Morgenpost&nbsp;&nbsp;(9)</option>
+	<option class="level-0" value="139">Berliner Zeitung&nbsp;&nbsp;(7)</option>
+	<option class="level-0" value="1256">berliner-kurier.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1255">berliner-zeitung.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1349">Bilanz&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="452">Bild&nbsp;&nbsp;(1.145)</option>
+	<option class="level-0" value="331">Bild am Sonntag&nbsp;&nbsp;(118)</option>
+	<option class="level-0" value="873">Bild.de&nbsp;&nbsp;(1.222)</option>
+	<option class="level-0" value="1365">Bildbetrachtung&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1035">BILDblog.de&nbsp;&nbsp;(19)</option>
+	<option class="level-0" value="245">Blick&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="229">Blick am Abend&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="972">blick.ch&nbsp;&nbsp;(30)</option>
+	<option class="level-0" value="1157">br.de&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1363">BR24&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1209">Brand Eins&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="550">Bravo&nbsp;&nbsp;(10)</option>
+	<option class="level-0" value="1100">Bravo Girl&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1392">Breitbart&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1408">Brigitte&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1110">Brigitte Woman&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1407">Brigitte.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1384">Bundeswehr&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1185">Bundeszentrale für politische Bildung&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1123">Bunte&nbsp;&nbsp;(11)</option>
+	<option class="level-0" value="1059">bunte.de&nbsp;&nbsp;(13)</option>
+	<option class="level-0" value="1385">Business Insider&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1348">Byou&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="983">bz-berlin.de&nbsp;&nbsp;(18)</option>
+	<option class="level-0" value="1350">celepedia.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1370">chiemgau24.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1277">chip.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1150">Christ &amp; Welt&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="666">Cicero&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1167">cicero.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1257">Closer&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1008">CNN.com&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1354">Compact&nbsp;&nbsp;(11)</option>
+	<option class="level-0" value="1047">Computer Bild&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1400">Correctiv&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1341">CSU&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1406">Daily Express&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1269">Daily Mail&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1042">Daily Mirror&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="974">dapd&nbsp;&nbsp;(40)</option>
+	<option class="level-0" value="1226">Darmstädter Echo&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1136">Das goldene Blatt&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1137">Das neue Blatt&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1041">ddp&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1141">Der Freitag&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="584">Der Standard&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="106">Der Westen&nbsp;&nbsp;(18)</option>
+	<option class="level-0" value="79">derstandard.at&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="1362">Deutschlandradio Kultur&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1249">Diabetes Journal&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1075">Die Aktuelle&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1017">Die Welt&nbsp;&nbsp;(28)</option>
+	<option class="level-0" value="131">Die Zeit&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="1230">DiePresse.com&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1245">Dithmarscher Landeszeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1083">Diverse&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1102">Domradio&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1244">Donaukurier&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="973">dpa&nbsp;&nbsp;(114)</option>
+	<option class="level-0" value="1165">Dresdner Morgenpost&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1190">Dresdner Neueste Nachrichten&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1087">DSF&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1225">dw.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1214">dwdl.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1124">emma.de&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1101">epd&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1391">Epoch Times&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1238">Eßlinger Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="840">Express&nbsp;&nbsp;(24)</option>
+	<option class="level-0" value="1002">express.de&nbsp;&nbsp;(40)</option>
+	<option class="level-0" value="995">FAZ.net&nbsp;&nbsp;(24)</option>
+	<option class="level-0" value="1074">Financial Times Deutschland&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1010">Focus&nbsp;&nbsp;(13)</option>
+	<option class="level-0" value="1045">focus.de&nbsp;&nbsp;(118)</option>
+	<option class="level-0" value="1080">FR-Online&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="976">fr-online.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1031">Frankfurter Allgemeine Sonntagszeitung&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1003">Frankfurter Allgemeine Zeitung&nbsp;&nbsp;(21)</option>
+	<option class="level-0" value="848">Frankfurter Rundschau&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1207">Frau aktuell&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1340">Frau im Spiegel&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1232">Frau mit Herz&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1389">freiepresse.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1158">Freizeit Spaß&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1037">ftd.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1111">Fuldaer Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1357">Für Sie Geklickt&nbsp;&nbsp;(14)</option>
+	<option class="level-0" value="1394">Fußball Bild&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="978">Gala&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1243">gala.de&nbsp;&nbsp;(6)</option>
+	<option class="level-0" value="1339">Gast-BILDblogger&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1356">Germanwings-Absturz&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1038">Gesunde Medizin&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="421">Getty Images&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1155">Global Press&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1048">Golem&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="997">Gong&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1266">Goslarsche Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1414">Grazia&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1040">Grusswort&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1267">Günther Jauch&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1358">hamburg1.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="609">Hamburger Abendblatt&nbsp;&nbsp;(12)</option>
+	<option class="level-0" value="969">Hamburger Morgenpost&nbsp;&nbsp;(26)</option>
+	<option class="level-0" value="733">Handelsblatt&nbsp;&nbsp;(8)</option>
+	<option class="level-0" value="1096">Handelsblatt.com&nbsp;&nbsp;(13)</option>
+	<option class="level-0" value="1072">Hannoversche Allgemeine&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1254">haz.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1027">heise.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="982">heute&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1071">Heute Journal&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1261">heute-show&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="981">heute.at&nbsp;&nbsp;(8)</option>
+	<option class="level-0" value="1011">heute.de&nbsp;&nbsp;(6)</option>
+	<option class="level-0" value="1108">hna.de&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="1086">Horizont&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1151">hr-online.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1189">HS-Woche&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1236">Huffingtonpost.de&nbsp;&nbsp;(40)</option>
+	<option class="level-0" value="1360">Im Abseits&nbsp;&nbsp;(25)</option>
+	<option class="level-0" value="1023">In eigener Sache&nbsp;&nbsp;(23)</option>
+	<option class="level-0" value="1068">In Touch&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1275">independent.co.uk&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1057">jetzt.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1338">joiz.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="149">Junge Welt&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1376">jungefreiheit.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1046">kai-diekmann.de&nbsp;&nbsp;(12)</option>
+	<option class="level-0" value="1352">Kicker&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="990">kicker.de&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1388">kleinezeitung.at&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1029">kn-online.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1020">KNA&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1049">Kölner Stadt-Anzeiger&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="988">Kölnische Rundschau&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1424">Kommentar&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1343">kreiszeitung.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1105">kress.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1015">krone.at&nbsp;&nbsp;(9)</option>
+	<option class="level-0" value="1019">Kronen Zeitung&nbsp;&nbsp;(8)</option>
+	<option class="level-0" value="999">ksta.de&nbsp;&nbsp;(9)</option>
+	<option class="level-0" value="1073">Kurier&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1239">kurier.at&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1250">L.A. Multimedia&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1264">LeFloid&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1142">Leipziger Volkszeitung&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1001">Lübecker Nachrichten&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1179">lvz-online.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1382">Mail on Sunday&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1227">Main Post&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1000">manager-magazin.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1274">Märkische Allgemeine&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="293">MDR&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1419">MDR.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="916">Meedia&nbsp;&nbsp;(6)</option>
+	<option class="level-0" value="985">merian.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1076">Merkur Online&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1077">merkur-online.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1014">metal-hammer.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1169">Micky Maus&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1347">mirror.co.uk&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1373">Mittelbayerische Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1372">mittelbayerische.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1021">mopo.de&nbsp;&nbsp;(27)</option>
+	<option class="level-0" value="1030">morgenpost.de&nbsp;&nbsp;(13)</option>
+	<option class="level-0" value="1024">MSN&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="998">Münchner Merkur&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1355">Mut zur Wirrheit&nbsp;&nbsp;(11)</option>
+	<option class="level-0" value="1081">n-tv&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1062">n-tv.de&nbsp;&nbsp;(22)</option>
+	<option class="level-0" value="480">N24&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1033">n24.de&nbsp;&nbsp;(9)</option>
+	<option class="level-0" value="1138">ndr.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1381">Neo Magazin Royale&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1064">Netzeitung&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1401">netzfrauen.org&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1050">Netzpolitik&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1145">Neue Osnabrücker Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1379">Neue Post&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="798">Neue Zürcher Zeitung&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1263">news.com.au&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1259">news.de&nbsp;&nbsp;(7)</option>
+	<option class="level-0" value="1399">newsweek.com&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1396">Nido&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1009">nordbayern.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1199">Nordkurier&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1278">nordkurier.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1378">Nürnberger Nachrichten&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1106">Nürnberger Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1044">nw-news.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="996">NZZ Online&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1067">oe24.at&nbsp;&nbsp;(21)</option>
+	<option class="level-0" value="1061">Offenbach-Post&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1368">Olympia&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1018">orf.at&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="94">Österreich&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1233">österreich.at&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1131">Ostsee-Zeitung&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1270">OWL am Sonntag&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1089">Passauer Neue Presse&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1273">Perlen des Lokaljournalismus&nbsp;&nbsp;(77)</option>
+	<option class="level-0" value="1383">planet-interview.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1371">pnp.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1377">Politically Correct!&nbsp;&nbsp;(14)</option>
+	<option class="level-0" value="984">Pro Sieben&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1025">pz-news.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1409">radioeins&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="975">rbb-online.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1139">recklinghaeuser-zeitung.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1039">Reuters&nbsp;&nbsp;(16)</option>
+	<option class="level-0" value="1191">Rhein-Zeitung&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="992">Rheinische Post&nbsp;&nbsp;(11)</option>
+	<option class="level-0" value="359">RP Online&nbsp;&nbsp;(26)</option>
+	<option class="level-0" value="1412">RT Deutsch&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="444">RTL&nbsp;&nbsp;(16)</option>
+	<option class="level-0" value="1088">rtl.de&nbsp;&nbsp;(11)</option>
+	<option class="level-0" value="1211">Ruhr Nachrichten&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1413">rundschau-online.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="977">Sächsische Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1367">Sat.1&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1173">Schleswig-Holsteinischer Zeitungsverlag&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1397">schwäbische.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1053">Schwäbisches Tagblatt&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="736">Schweizer Illustrierte&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1093">SDA&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="281">SF&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1004">Sf.tv&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1234">shz.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="989">sid&nbsp;&nbsp;(23)</option>
+	<option class="level-0" value="1144">Sky&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1411">skysport.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1272">Sonntagszeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="264">Spiegel&nbsp;&nbsp;(21)</option>
+	<option class="level-0" value="119">Spiegel Online&nbsp;&nbsp;(141)</option>
+	<option class="level-0" value="1147">Spiegel TV&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1116">Sport Bild&nbsp;&nbsp;(12)</option>
+	<option class="level-0" value="1058">sport1.de&nbsp;&nbsp;(7)</option>
+	<option class="level-0" value="1007">sportbild.de&nbsp;&nbsp;(15)</option>
+	<option class="level-0" value="1210">Spot On&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1344">spox.com&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1359">Sputnik&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1345">St. Georg&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1369">Stader Tageblatt&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1026">standard.at&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1056">Star&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1366">Steiner Anzeiger&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="991">Stern&nbsp;&nbsp;(14)</option>
+	<option class="level-0" value="1260">Stern TV&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="986">stern.de&nbsp;&nbsp;(66)</option>
+	<option class="level-0" value="1082">Stuttgarter Nachrichten&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="987">Stuttgarter Zeitung&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1022">stuttgarter-zeitung.de&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="1156">stylebook.de&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="127">Süddeutsche Zeitung&nbsp;&nbsp;(30)</option>
+	<option class="level-0" value="492">Südkurier&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1028">Südwest Presse&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="651">sueddeutsche.de&nbsp;&nbsp;(43)</option>
+	<option class="level-0" value="1241">Superillu&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="994">t-online.de&nbsp;&nbsp;(9)</option>
+	<option class="level-0" value="1393">tag24.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="404">Tagesanzeiger&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1220">Tagesanzeiger.ch&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="218">Tagesschau&nbsp;&nbsp;(11)</option>
+	<option class="level-0" value="971">tagesschau.de&nbsp;&nbsp;(10)</option>
+	<option class="level-0" value="392">Tagesspiegel&nbsp;&nbsp;(9)</option>
+	<option class="level-0" value="1036">tagesspiegel.de&nbsp;&nbsp;(6)</option>
+	<option class="level-0" value="278">Tagesthemen&nbsp;&nbsp;(8)</option>
+	<option class="level-0" value="1231">Taunus Zeitung&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="519">taz&nbsp;&nbsp;(7)</option>
+	<option class="level-0" value="1090">taz.de&nbsp;&nbsp;(16)</option>
+	<option class="level-0" value="1098">Telepolis&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1364">The European&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1262">The Independent&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1055">The Sun&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1127">Thüringer Allgemeine&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="769">Titanic&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1228">Trierischer Volksfreund&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1280">TV Movie&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="541">Twitter&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1051">tz&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="1118">tz-online.de&nbsp;&nbsp;(4)</option>
+	<option class="level-0" value="1402">unzensuriert.at&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1078">Viel Spaß&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1032">volksfreund.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1013">volksstimme.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1085">w&amp;v&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1178">wallstreetjournal.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1386">Washington Post&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1418">Watson&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="528">WAZ&nbsp;&nbsp;(10)</option>
+	<option class="level-0" value="1390">waz.de&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="328">WDR&nbsp;&nbsp;(5)</option>
+	<option class="level-0" value="1016">Welt am Sonntag&nbsp;&nbsp;(13)</option>
+	<option class="level-0" value="980">Welt Kompakt&nbsp;&nbsp;(8)</option>
+	<option class="level-0" value="323">Welt Online&nbsp;&nbsp;(87)</option>
+	<option class="level-0" value="1069">Weser-Kurier&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1054">Westdeutsche Zeitung&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1271">Westfalenblatt&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1346">Westfälische Nachrichten&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1043">Westfälische Rundschau&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1109">Westfälischer Anzeiger&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1140">westline.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1195">wiesbadener-kurier.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1052">Wiwo.de&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1258">Woche heute&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1395">Wochenblick&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1200">wz-newsline.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1353">Yahoo&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="317">ZDF&nbsp;&nbsp;(10)</option>
+	<option class="level-0" value="1012">zdf.de&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1380">ZDFneo&nbsp;&nbsp;(1)</option>
+	<option class="level-0" value="1279">ze.tt&nbsp;&nbsp;(2)</option>
+	<option class="level-0" value="1206">Zeit Magazin&nbsp;&nbsp;(3)</option>
+	<option class="level-0" value="1006">Zeit Online&nbsp;&nbsp;(23)</option>
+</select>
+             <script type="text/javascript"><!--
+    var dropdown = document.getElementById("cat");
+    function onCatChange() {
+		if ( dropdown.options[dropdown.selectedIndex].value > 0 ) {
+			location.href = "https://bildblog.de/?cat="+dropdown.options[dropdown.selectedIndex].value;
+		}
+    }
+    dropdown.onchange = onCatChange;
+--></script>
+         </div>
+</div>
+
+<div class="navimenu">
+	<div class="navimenu-title-neu"><span class="navimenu-title-span">BILDblog abonnieren</span></div>
+	<ul>
+		<li><a href="/bildblog-abonnieren/"><b>Updates</b> per E-Mail erhalten</a>
+		</li>
+	</ul>
+</div>
+
+<div id="adspace" class="navimenu">
+	<div class="navimenu-title-neu"><span class="navimenu-title-span">Anzeige</span></div>
+	<a href="https://www.mydealz.de/"><img src='/wp-content/mydealzlogo.png' alt='MyDealz' /></a>
+	<style>
+		.rss-widget-icon, .widget_rss .widget-title {display: none;}
+	</style>
+
+<div id="rss-2" class="widget-1 widget-first widget widget_rss"><h3 class="widget-title"><a class="rsswidget" href="http://feeds.feedburner.com/mydealz"><img class="rss-widget-icon" style="border:0" width="14" height="14" src="https://bildblog.de/wp-includes/images/rss.png" alt="RSS" /></a> <a class="rsswidget" href="https://www.mydealz.de/">mydealz</a></h3><ul><li><a class='rsswidget' href='http://feedproxy.google.com/~r/myDealZ/~3/HAwh1xsZBcQ/id-1218890'>Sonnenbrille + Lipton ICE Tea + McChicken Classic [McDonalds App]</a></li><li><a class='rsswidget' href='http://feedproxy.google.com/~r/myDealZ/~3/cd9dPc8WzfM/id-1218859'>Google Chromecast 2 für 29€ [mediamarkt]</a></li><li><a class='rsswidget' href='http://feedproxy.google.com/~r/myDealZ/~3/ujFoIY514N4/id-1210340'>Efteling (NL) Tagesticket und Parken</a></li><li><a class='rsswidget' href='http://feedproxy.google.com/~r/myDealZ/~3/8jxa_rCB2Kw/id-1218826'>AVM FRITZ Box 6490 Cable WLAN Dualband Kabelmodem Router + AVM FRITZ!WLAN Repeater 1160 für 165,-€ [Mediamarkt]</a></li><li><a class='rsswidget' href='http://feedproxy.google.com/~r/myDealZ/~3/qkSpUKjK_Hk/id-1187479'>Deutsche Bahn Sommer-Ticket - 4 Fahrten für junge Menschen für 76€ bzw. 96€</a></li></ul></div></div>
+
+<div class="navimenu">
+ <div class="navimenu-title-neu"><span class="navimenu-title-span">Hosting</span></div>
+<a href="http://www.manitu.de/"><img style="margin-top:2px;" src='/wp-content/manitu_greenhostedby234_60.gif' alt='Manitu' /></a>
+</div>
+
+<div class="navimenu">
+	<div class="navimenu-title-neu">
+		<span class="navimenu-title-span">Extras</span>
+	</div>
+	<ul>
+		<li><a href="/impressum/">Impressum</li>
+		<li><a href="/datenschutz/">Datenschutzerklärung</li>
+		<li><a href="/2446/in-eigener-sache-der-bildblog-werbespot">BILDblog-Werbespot</a></li>
+		<li><a href="/schlagzeilomat.html">Schlagzeil-o-mat</a></li>
+		<li><a href="/auflage">"Bild"-Auflage</a></li>
+		<li><a href="/hilfe-ich-bin-in-bild-teil-1/">Ratgeber: Hilfe, ich bin in "Bild"</a></li>
+		<li><a href="/2804">Wer liest BILDblog?</a></li>
+	</ul>
+</div>
+
+<div class="navimenu">
+<div class="navimenu-title-neu"><span class="navimenu-title-span">Oldies</span></div>
+<ul><li><a href="/gallery/bildblog-postkarten/">BILDblog-Werbepostkarten</a></li>
+<li><a href="/bild-woerterbuch/">"Bild"-Wörterbuch</a></li>
+<li><a href="/presseratsruegen-fuer-bild/">Presserats-Rügen für "Bild"</a></li>
+<li><a href="/?cat=3&amp;order=asc">Wir fotografieren zurück: Das BILDblog-Experiment</a></li>
+<li><a href="/?page_id=1972">Advent 2006: BILDblog-Adventskalender</a></li>
+<li><a href="/2634/die-grosse-bildblog-adventsaktion">Advent 2007: BILDblogger für einen Tag</a></li>
+<li><a href="/ressort/bildblog-vor-40-jahren/">Weihnachten 2008: BILDblog vor 40 Jahren</a></li>
+<li><a href="/ressort/advent-2011/">Advent 2011: BILDblog classics</a></li>
+</ul></div>
+
+ <div class="navimenu-title-neu">
+	 <span class="navimenu-title-span">Archiv</span>
+ </div>
+ <div id="calendar_wrap">
+	 <table id="wp-calendar">
+	<caption>August 2018</caption>
+	<thead>
+	<tr>
+		<th scope="col" title="Montag">M</th>
+		<th scope="col" title="Dienstag">D</th>
+		<th scope="col" title="Mittwoch">M</th>
+		<th scope="col" title="Donnerstag">D</th>
+		<th scope="col" title="Freitag">F</th>
+		<th scope="col" title="Samstag">S</th>
+		<th scope="col" title="Sonntag">S</th>
+	</tr>
+	</thead>
+
+	<tfoot>
+	<tr>
+		<td colspan="3" id="prev"><a href="https://bildblog.de/date/2018/07/">&laquo; Jul</a></td>
+		<td class="pad">&nbsp;</td>
+		<td colspan="3" id="next" class="pad">&nbsp;</td>
+	</tr>
+	</tfoot>
+
+	<tbody>
+	<tr>
+		<td colspan="2" class="pad">&nbsp;</td><td><a href="https://bildblog.de/date/2018/08/01/" aria-label="Beiträge veröffentlicht am 1. August 2018">1</a></td><td><a href="https://bildblog.de/date/2018/08/02/" aria-label="Beiträge veröffentlicht am 2. August 2018">2</a></td><td><a href="https://bildblog.de/date/2018/08/03/" aria-label="Beiträge veröffentlicht am 3. August 2018">3</a></td><td>4</td><td>5</td>
+	</tr>
+	<tr>
+		<td><a href="https://bildblog.de/date/2018/08/06/" aria-label="Beiträge veröffentlicht am 6. August 2018">6</a></td><td><a href="https://bildblog.de/date/2018/08/07/" aria-label="Beiträge veröffentlicht am 7. August 2018">7</a></td><td><a href="https://bildblog.de/date/2018/08/08/" aria-label="Beiträge veröffentlicht am 8. August 2018">8</a></td><td><a href="https://bildblog.de/date/2018/08/09/" aria-label="Beiträge veröffentlicht am 9. August 2018">9</a></td><td><a href="https://bildblog.de/date/2018/08/10/" aria-label="Beiträge veröffentlicht am 10. August 2018">10</a></td><td>11</td><td>12</td>
+	</tr>
+	<tr>
+		<td><a href="https://bildblog.de/date/2018/08/13/" aria-label="Beiträge veröffentlicht am 13. August 2018">13</a></td><td><a href="https://bildblog.de/date/2018/08/14/" aria-label="Beiträge veröffentlicht am 14. August 2018">14</a></td><td><a href="https://bildblog.de/date/2018/08/15/" aria-label="Beiträge veröffentlicht am 15. August 2018">15</a></td><td id="today">16</td><td>17</td><td>18</td><td>19</td>
+	</tr>
+	<tr>
+		<td>20</td><td>21</td><td>22</td><td>23</td><td>24</td><td>25</td><td>26</td>
+	</tr>
+	<tr>
+		<td>27</td><td>28</td><td>29</td><td>30</td><td>31</td>
+		<td class="pad" colspan="2">&nbsp;</td>
+	</tr>
+	</tbody>
+	</table> </div>
+
+
+<ul>
+	</ul>
+	
+	
+</aside>	</div>
+</div>
+</div>
+<div id="viceContentAd" data-src="a-BILDblog-6-vor-9" style="position: absolute; height: 0;"></div><script type='text/javascript' src='https://advice-ads-cdn.vice.com/DE/viceIVW-CS.js?ver=1'></script>
+<script defer  type='text/javascript' src='https://bildblog.de/wp-content/plugins/google-analytics-opt-out/js/frontend.js?ver=4.9.6'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/comment-reply.min.js?ver=4.9.6'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var wpcf7 = {"apiSettings":{"root":"https:\/\/bildblog.de\/wp-json\/contact-form-7\/v1","namespace":"contact-form-7\/v1"},"recaptcha":{"messages":{"empty":"Please verify that you are not a robot."}}};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://bildblog.de/wp-content/plugins/contact-form-7/includes/js/scripts.js?ver=5.0.2'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/core.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/widget.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/mouse.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/resizable.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/draggable.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/button.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/position.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/jquery/ui/dialog.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-includes/js/wp-embed.min.js?ver=4.9.6'></script>
+<script type='text/javascript' src='https://bildblog.de/wp-content/themes/Frank-advice/js/mydealz.js?ver=1.1'></script>
+
+		 
+</body>
+</html>

--- a/api/test/workers/rss.js
+++ b/api/test/workers/rss.js
@@ -96,6 +96,8 @@ describe('RSS worker', () => {
 		];
 
 		for (let i = 0; i < testCases.length; ++i) {
+			continue;
+
 			it(`should call worker when enqueueing job for ${testCases[i]}`, async () => {
 				async function queue(url) {
 					setupHandler();
@@ -111,7 +113,7 @@ describe('RSS worker', () => {
 					.reply(200, () => getTestFeed(url.host));
 				await queue(testCases[i]);
 				nock.cleanAll();
-			}).timeout(30000).retries(3);
+			}).timeout(30000).retries(2);
 		}
 
 		it('should fail for invalid job', async () => {

--- a/api/test/workers/rss.js
+++ b/api/test/workers/rss.js
@@ -111,7 +111,7 @@ describe('RSS worker', () => {
 					.reply(200, () => getTestFeed(url.host));
 				await queue(testCases[i]);
 				nock.cleanAll();
-			}).retries(2);
+			}).timeout(30000).retries(3);
 		}
 
 		it('should fail for invalid job', async () => {

--- a/api/test/workers/rss.js
+++ b/api/test/workers/rss.js
@@ -96,7 +96,6 @@ describe('RSS worker', () => {
 		];
 
 		for (let i = 0; i < testCases.length; ++i) {
-			continue;
 
 			it(`should call worker when enqueueing job for ${testCases[i]}`, async () => {
 				async function queue(url) {

--- a/api/test/workers/rss.js
+++ b/api/test/workers/rss.js
@@ -51,7 +51,7 @@ describe('RSS worker', () => {
 	});
 
 	describe('queue', () => {
-		const testCases = [];[
+		const testCases = [
 			'http://20minutes.fr/rss/france.xml',
 			'http://20minutes.fr/rss/hightech.xml',
 			'http://20minutes.fr/rss/paris.xml',

--- a/api/test/workers/rss.js
+++ b/api/test/workers/rss.js
@@ -111,7 +111,7 @@ describe('RSS worker', () => {
 					.reply(200, () => getTestFeed(url.host));
 				await queue(testCases[i]);
 				nock.cleanAll();
-			}).timeout(30000).retries(3);
+			}).retries(2);
 		}
 
 		it('should fail for invalid job', async () => {


### PR DESCRIPTION
### Description of the Change

Use Redis to store parsing state flags:

For podcast/rss queues we use a sorted set with timestamps as score. This is necessary to be able to retrieve ids of currently parsing feeds. Timestamp scores are used to evict expired ids.
For og/stream/social queues we use regular key-value pairs with expiration as we only care about presence/absence of key in Redis.

This approach would make parsing state fail-safe against crashing workers, queue issues.