### PR TITLE
Auto hide menu bar on Windows and Linux

### DIFF
--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -28,6 +28,7 @@ const createWindow = () => {
 		},
 		height: 860,
 		width: 1280,
+		autoHideMenuBar: true
 	});
 
 	mainWindow.loadURL(


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

A LOT of users hate the look of the menu bar so it would be awesome to hide it. This is only a problem on Windows and Linux because macOS hides the application menu bar at the top of the screen.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be in Core?

<!-- Explain why this functionality should be in GetStream/Winds as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
