### PR TITLE
sanitize-html returns a string 'undefined' when content is empty, I c…

### DIFF
--- a/api/src/models/episode.js
+++ b/api/src/models/episode.js
@@ -174,7 +174,8 @@ EpisodeSchema.methods.getParsedEpisode = async function() {
 
 		if (!title) return null;
 
-		const content = sanitize(parsed.content);
+		const sanitizedContent = sanitize(parsed.content);
+		const content = sanitizedContent != 'undefined' ? sanitizedContent : '<p></p>';
 		return await Content.create({
 			content,
 			title,


### PR DESCRIPTION
According to this issue https://github.com/apostrophecms/sanitize-html/issues/81, the sanitize-html may return 'undefined' string when episode content is empty.

I made episode.js change this 'undefined' string for an empty paragraph.

I also tried to persist an empty string as content, instead of `<p></p>`, but PodcastEpisode.js understand empty content as an error and shows an error message.