### PR TITLE
Visual changes, copy tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Winds is packed full of awesome features behind a beautiful user interface and u
 
 ## Roadmap
 
-Help us improve Winds and/or vote on the [Roadmap for 2.1](https://github.com/GetStream/Winds/issues/191)
-
 *   [ ] Search detail screen
 *   [ ] Playlist support (partially implemented)
 *   [ ] Team support (share an activity feed with colleagues or friends to discover and collaborate)

--- a/app/src/components/FeaturedItems.js
+++ b/app/src/components/FeaturedItems.js
@@ -48,7 +48,7 @@ class FeaturedItems extends React.Component {
 									className="featured-item"
 									key={featuredItem._id}
 									style={{
-										backgroundImage: `linear-gradient(to top, black, transparent),
+										backgroundImage: `linear-gradient(0deg, #00000088 30%, #ffffff44 100%),
 										url(${featuredItem.images.featured || getPlaceholderImageURL(featuredItem._id)})`,
 									}}
 									to={linkURL}

--- a/app/src/components/FeaturedItems.js
+++ b/app/src/components/FeaturedItems.js
@@ -54,7 +54,6 @@ class FeaturedItems extends React.Component {
 									to={linkURL}
 								>
 									<h1>{featuredItem.title}</h1>
-									<p />
 									<label>{featuredItem.type}</label>
 								</Link>
 							);

--- a/app/src/components/SearchBar.js
+++ b/app/src/components/SearchBar.js
@@ -186,7 +186,7 @@ class SearchBar extends React.Component {
 									this.setState({ displayResults: true });
 							}}
 							onKeyDown={this.handleKeyDown}
-							placeholder="Search Winds..."
+							placeholder="Search for shows, articles, or sources"
 							ref={(element) => {
 								this.inputElement = element;
 							}}

--- a/app/src/components/TimeAgo/index.js
+++ b/app/src/components/TimeAgo/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 moment.updateLocale('en', {
 	relativeTime: {
-		past: '%s Ago',
+		past: '%s ago',
 		s: 's',
 		ss: '%ds',
 		m: '%dmin',

--- a/app/src/styles/components/_columns.scss
+++ b/app/src/styles/components/_columns.scss
@@ -74,7 +74,7 @@ a.column-header:hover,
 	border-image: linear-gradient(to top, #ebebeb, #f7f7f7) 1 100%;
 	border-right-style: solid;
 	border-right-width: 5px;
-	overflow-y: scroll;
+	overflow-y: auto;
 	padding-left: 20px;
 	padding-right: 20px;
 	width: 33.33333%;
@@ -138,7 +138,7 @@ a.column-header:hover,
 
 	.column-content {
 		height: 100%;
-		overflow-y: scroll;
+		overflow-y: auto;
 
 		&::-webkit-scrollbar {
 			display: none;

--- a/app/src/styles/elements/_buttons.scss
+++ b/app/src/styles/elements/_buttons.scss
@@ -174,4 +174,7 @@
 	svg {
 		margin: 0 12px 0 4px;
 	}
+	&:active {
+		filter: brightness(0.9);
+	}
 }

--- a/app/src/styles/elements/_drawer.scss
+++ b/app/src/styles/elements/_drawer.scss
@@ -13,7 +13,7 @@
 
 	.drawer-container {
 		height: 100%;
-		overflow-y: scroll;
+		overflow-y: auto;
 
 		.form-section {
 			h2 {
@@ -87,7 +87,7 @@
 		footer {
 			align-items: center;
 			bottom: 0;
-			box-shadow: $box-shadow;
+			border-top: 1px solid $foreground-mediumgray;
 			display: flex;
 			height: 60px;
 			left: 0;

--- a/app/src/styles/elements/_drawer.scss
+++ b/app/src/styles/elements/_drawer.scss
@@ -65,6 +65,7 @@
 
 			input[type='checkbox'] {
 				margin-right: 0.6em;
+				accent-color: $medium-sea-green;
 			}
 
 			textarea {

--- a/app/src/styles/elements/_drawer.scss
+++ b/app/src/styles/elements/_drawer.scss
@@ -1,7 +1,7 @@
 .drawer {
 	background-color: $background-white;
 	bottom: 0;
-	box-shadow: $box-shadow;
+	box-shadow: $mega-box-shadow;
 	color: $foreground-black;
 	padding: 2em;
 	padding-bottom: 0;
@@ -111,6 +111,8 @@
 	right: 0;
 	top: 0;
 	z-index: 100000;
+	background: rgba(0,0,0,0.48);
+	
 }
 
 .delete-account-confirmation-popover,

--- a/app/src/styles/elements/_tabs.scss
+++ b/app/src/styles/elements/_tabs.scss
@@ -3,7 +3,7 @@
 	margin: 0;
 	margin-bottom: 2em;
 	min-height: 2em;
-	padding-left: 1em;
+	padding-left: 0;
 
 	.tab {
 		color: $foreground-darkgray;

--- a/app/src/styles/framework/dashboard/_header.scss
+++ b/app/src/styles/framework/dashboard/_header.scss
@@ -182,7 +182,7 @@
 				img {
 					background: #20c691;
 					border-radius: 50%;
-					box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.17);
+					border: 1px solid rgb(60 60 67 / 29%);
 					cursor: pointer;
 				}
 			}

--- a/app/src/styles/framework/dashboard/_header.scss
+++ b/app/src/styles/framework/dashboard/_header.scss
@@ -152,6 +152,10 @@
 					height: 28px;
 					padding: 0 12px;
 					width: 100%;
+					font-family: $primary;
+    					font-weight: 400;
+    					font-size: 1.15em;
+					}
 				}
 
 				&.banner-is-shown {

--- a/app/src/styles/framework/dashboard/_header.scss
+++ b/app/src/styles/framework/dashboard/_header.scss
@@ -99,21 +99,20 @@
 
 			.logo {
 				opacity: 0.5;
-				transition: 0.3s ease-in-out;
+				transition: 0.15s ease-in-out;
 
-				&:hover {
+				&:
+				{
 					opacity: 1;
-					transition: 0.3s ease-in-out;
 				}
 			}
 
 			.refresh {
 				opacity: 0.5;
-				transition: 0.3s ease-in-out;
+				transition: 0.15s ease-in-out;
 
 				&:hover {
 					opacity: 1;
-					transition: 0.3s ease-in-out;
 				}
 			}
 
@@ -167,6 +166,7 @@
 					position: absolute;
 					right: 8px;
 					top: 6px;
+					filter: brightness(0.5);
 				}
 			}
 		}

--- a/app/src/styles/modules/_featured-items-section.scss
+++ b/app/src/styles/modules/_featured-items-section.scss
@@ -60,13 +60,13 @@
 
 			h1 {
 				margin-bottom: 0;
+				margin-top: 4px;
 				font-size: 1.65em;
 
 			}
 
 			label {
 				color: $foreground-white;
-				margin-bottom: auto;
 				font-size: 1em;
 			}
 		}

--- a/app/src/styles/modules/_featured-items-section.scss
+++ b/app/src/styles/modules/_featured-items-section.scss
@@ -47,6 +47,7 @@
 			width: 200px;
 			object-fit: cover;
 			box-shadow: 0 6px 18px 0 rgba(15,40,34,0.10);
+			text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 			transition-duration: 0.3s;
 			transition-property: transform;
 

--- a/app/src/styles/views/_dashboard.scss
+++ b/app/src/styles/views/_dashboard.scss
@@ -23,8 +23,8 @@
 
 	.border1,
 	.border2 {
-		background: linear-gradient(to top, #ebebeb, #f7f7f7);
-		width: 5px;
+		background: $background-lightgray;
+		width: 1px;
 	}
 
 	.podcast-header {

--- a/app/src/styles/views/_dashboard.scss
+++ b/app/src/styles/views/_dashboard.scss
@@ -65,7 +65,7 @@
 	.rss-section,
 	.folder-section {
 		min-width: 0;
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 
 	.podcast-header,

--- a/app/src/styles/views/_folder.scss
+++ b/app/src/styles/views/_folder.scss
@@ -40,7 +40,7 @@
 	.results.panel {
 		margin-top: 0;
 		max-height: 200px;
-		overflow-y: scroll;
+		overflow-y: auto;
 
 		.type {
 			background-color: rgba(0, 0, 0, 0.06);
@@ -107,7 +107,7 @@
 
 .tag-popover {
 	max-height: 260px;
-	overflow-y: scroll;
+	overflow-y: auto;
 	width: 230px;
 
 	.panel-element {

--- a/app/src/styles/views/_grid.scss
+++ b/app/src/styles/views/_grid.scss
@@ -25,7 +25,7 @@
 	.panels {
 		grid-area: panels;
 		min-width: 0;
-		overflow-y: scroll;
+		overflow-y: auto;
 		user-select: none;
 	}
 
@@ -38,7 +38,7 @@
 	.content {
 		grid-area: content;
 		max-width: 100%;
-		overflow-y: scroll;
+		overflow-y: auto;
 
 		.enclosures {
 			margin: auto;


### PR DESCRIPTION
### Description of the Change
These include mostly visual changes to tighten up the interface and make it more accessible. Slight tweaks to the copy are also included.

### Alternate Designs
Since all of my changes are straight-forward and explained in the different commit messages, I'll use this to spitball some other designs I had in mind but wasn't able to implement for one reason or another:

- The title bar may not be needed. The web app handles the standard browser back button fine and the reload button is deadweight. The PWA on Windows also has a refresh and back button, so they aren't needed there.
- The version string can be added to the page title or just above the settings drawer's footer
- I can't figure out where the popover code is but the animations are a bit much, might want to speed those up and reduce the distance it has to travel when sliding in. It should at least respect the prefers-reduced-motion setting.
- Loading favicons fail more often than not when using the strict https://xyz.com**/favicon.ico** pattern, might want to use something like [Google's S2 favicon API](https://www.google.com/s2/favicons?sz=32&domain_url=getstream.io) or [FaviconKit](https://api.faviconkit.com/getstream.io/32).

### Benefits
Animations are tighter, colors more closely adhere to WCAG AA standards.

### Applicable Issues
I [removed a rogue <p>](https://github.com/GetStream/Winds/commit/009c31866e7434a90060139fafbb92bbb662215d) from the featured content card, I don't think this was used for anything but if it is or breaks something, feel free to reject that change.
